### PR TITLE
fix: re-use tcp connections where possible

### DIFF
--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -630,7 +630,10 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 							return
 						}
 
-						defer resp.Body.Close()
+						// must read body and close the response for keepalived conns
+						_, _ = io.ReadAll(resp.Body)
+						_ = resp.Body.Close()
+
 						RecordIngressRequestDuration(time.Since(ingressStart))
 					}()
 				}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

For http client to be able to re-use existing tcp connections we need to read each response's body fully, and then close the response itself.
