### PR TITLE
chore: rebase `release` onto `main`

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -839,7 +839,7 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 			httpRes, _ := http.DefaultClient.Do(ingressReq)
 			httpRes.Body.Close()
 		}()
-	}	
+	}
 
 	start := time.Now()
 	httpRes, err := b.client.DoLimited(httpReq)

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -840,9 +840,14 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 			}
 
 			ingressStart := time.Now()
-			httpRes, _ := http.DefaultClient.Do(ingressReq)
-			httpRes.Body.Close()
-			RecordIngressRequestDuration(b.Name, time.Since(ingressStart))
+			httpRes, err := http.DefaultClient.Do(ingressReq)
+			if err != nil {
+				log.Warn("failed to proxy to ingress rpc", err)
+			} else {
+				defer httpRes.Body.Close()
+				RecordIngressRequestDuration(b.Name, time.Since(ingressStart))
+			}
+
 		}()
 	}
 

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -830,14 +830,19 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 	if b.ingressRPC != "" {
 		// Send async copy to ingress service, don't wait for error handling
 		go func() {
+			RecordIngressRequest(b.Name)
+
 			ingressReq, _ := http.NewRequestWithContext(ctx, "POST", b.ingressRPC, bytes.NewReader(body))
 			ingressReq.Header.Set("content-type", "application/json")
 			ingressReq.Header.Set("X-Forwarded-For", xForwardedFor)
 			for name, value := range b.headers {
 				ingressReq.Header.Set(name, value)
 			}
+
+			ingressStart := time.Now()
 			httpRes, _ := http.DefaultClient.Do(ingressReq)
 			httpRes.Body.Close()
+			RecordIngressRequestDuration(b.Name, time.Since(ingressStart))
 		}()
 	}
 

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -311,6 +311,7 @@ type Backend struct {
 	maxWSConns           int
 	outOfServiceInterval time.Duration
 	stripTrailingXFF     bool
+	ingressRPC           string
 	proxydIP             string
 
 	skipIsSyncingCheck bool
@@ -471,6 +472,12 @@ func WithMaxErrorRateThreshold(maxErrorRateThreshold float64) BackendOpt {
 func WithConsensusReceiptTarget(receiptsTarget string) BackendOpt {
 	return func(b *Backend) {
 		b.receiptsTarget = receiptsTarget
+	}
+}
+
+func WithIngressRPC(ingressRPC string) BackendOpt {
+	return func(b *Backend) {
+		b.ingressRPC = ingressRPC
 	}
 }
 
@@ -819,6 +826,20 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 	for name, value := range b.headers {
 		httpReq.Header.Set(name, value)
 	}
+
+	if b.ingressRPC != "" {
+		// Send async copy to ingress service, don't wait for error handling
+		go func() {
+			ingressReq, _ := http.NewRequestWithContext(ctx, "POST", b.ingressRPC, bytes.NewReader(body))
+			ingressReq.Header.Set("content-type", "application/json")
+			ingressReq.Header.Set("X-Forwarded-For", xForwardedFor)
+			for name, value := range b.headers {
+				ingressReq.Header.Set(name, value)
+			}
+			httpRes, _ := http.DefaultClient.Do(ingressReq)
+			httpRes.Body.Close()
+		}()
+	}	
 
 	start := time.Now()
 	httpRes, err := b.client.DoLimited(httpReq)

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -2,6 +2,7 @@ package proxyd
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -209,6 +210,75 @@ func TestAllowedStatusCodes(t *testing.T) {
 	require.Equal(t, -32000, res[0].Error.Code)
 	require.Equal(t, "backend has a foo problem", res[0].Error.Message)
 	require.Equal(t, http.StatusServiceUnavailable, res[0].Error.HTTPErrorCode)
+}
+
+func TestIngressForwarding(t *testing.T) {
+	backendRequests := make(chan []byte, 10)
+	ingressRequests := make(chan []byte, 10)
+
+	// Mock backend server
+	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		backendRequests <- body
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":"0x1234","id":1}`))
+	}))
+	defer backendServer.Close()
+
+	// Mock ingress server
+	ingressServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		ingressRequests <- body
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":"ok","id":1}`))
+	}))
+	defer ingressServer.Close()
+
+	// Create backend with ingress RPC configured
+	backend := NewBackend(
+		"test-backend",
+		backendServer.URL,
+		"",
+		semaphore.NewWeighted(10),
+		WithIngressRPC(ingressServer.URL),
+	)
+
+	// Create a test RPC request
+	rpcReq := &RPCReq{
+		JSONRPC: "2.0",
+		Method:  "eth_blockNumber",
+		Params:  []byte(`[]`),
+		ID:      []byte(`1`),
+	}
+
+	// Forward the request
+	ctx := context.Background()
+	res, err := backend.Forward(ctx, []*RPCReq{rpcReq}, false)
+
+	// Verify the backend request was successful
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.False(t, res[0].IsError())
+
+	// Verify both backend and ingress received the request
+	select {
+	case backendBody := <-backendRequests:
+		require.Contains(t, string(backendBody), "eth_blockNumber")
+		require.Contains(t, string(backendBody), `"id":1`)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Backend did not receive request")
+	}
+
+	// Give a bit more time for the async ingress request to complete
+	select {
+	case ingressBody := <-ingressRequests:
+		require.Contains(t, string(ingressBody), "eth_blockNumber")
+		require.Contains(t, string(ingressBody), `"id":1`)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Ingress did not receive request")
+	}
 }
 
 func getHttpResponseCodeCount(statusCode string) float64 {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -137,6 +137,8 @@ type BackendConfig struct {
 	ConsensusForcedCandidate    bool   `toml:"consensus_forced_candidate"`
 	ConsensusReceiptsTarget     string `toml:"consensus_receipts_target"`
 	AllowedStatusCodes          []int  `toml:"allowed_status_codes"`
+
+	IngressRPC string `toml:"ingress_rpc"`
 }
 
 type BackendsConfig map[string]*BackendConfig

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -251,6 +251,7 @@ type Config struct {
 	SenderRateLimit              SenderRateLimitConfig        `toml:"sender_rate_limit"`
 	InteropValidationConfig      InteropValidationConfig      `toml:"interop_validation"`
 	TxValidationMiddlewareConfig TxValidationMiddlewareConfig `toml:"tx_validation_middleware"`
+	IngressRPC              string                  `toml:"ingress_rpc"`
 }
 
 type InteropValidationConfig struct {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -251,7 +251,7 @@ type Config struct {
 	SenderRateLimit              SenderRateLimitConfig        `toml:"sender_rate_limit"`
 	InteropValidationConfig      InteropValidationConfig      `toml:"interop_validation"`
 	TxValidationMiddlewareConfig TxValidationMiddlewareConfig `toml:"tx_validation_middleware"`
-	IngressRPC              string                  `toml:"ingress_rpc"`
+	IngressRPC                   string                       `toml:"ingress_rpc"`
 }
 
 type InteropValidationConfig struct {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -137,8 +137,6 @@ type BackendConfig struct {
 	ConsensusForcedCandidate    bool   `toml:"consensus_forced_candidate"`
 	ConsensusReceiptsTarget     string `toml:"consensus_receipts_target"`
 	AllowedStatusCodes          []int  `toml:"allowed_status_codes"`
-
-	IngressRPC string `toml:"ingress_rpc"`
 }
 
 type BackendsConfig map[string]*BackendConfig

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -480,6 +480,14 @@ var (
 		"backend_name",
 	})
 
+	ingressRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "tips_ingress_requests_total",
+		Help:      "Count of total requests forwarded to TIPS ingress service.",
+	}, []string{
+		"backend_name",
+	})
+
 	backendProbeChecksTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "backend_probe_checks_total",
@@ -494,6 +502,15 @@ var (
 		Name:      "backend_probe_duration_seconds",
 		Help:      "Histogram of backend probe durations",
 		Buckets:   []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	}, []string{
+		"backend_name",
+	})
+
+	ingressRequestDurationSumm = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace:  MetricsNamespace,
+		Name:       "tips_ingress_request_duration_seconds",
+		Help:       "Summary of TIPS ingress request response times broken down by backend.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
 	}, []string{
 		"backend_name",
 	})
@@ -684,6 +701,14 @@ func RecordBackendProbeCheck(backendName string, success bool) {
 
 func RecordBackendProbeDuration(backendName string, duration time.Duration) {
 	backendProbeDurationHist.WithLabelValues(backendName).Observe(duration.Seconds())
+}
+
+func RecordIngressRequest(backendName string) {
+	ingressRequestsTotal.WithLabelValues(backendName).Inc()
+}
+
+func RecordIngressRequestDuration(backendName string, duration time.Duration) {
+	ingressRequestDurationSumm.WithLabelValues(backendName).Observe(duration.Seconds())
 }
 
 func boolToFloat64(b bool) float64 {

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -480,12 +480,10 @@ var (
 		"backend_name",
 	})
 
-	ingressRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	ingressRequestsTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "tips_ingress_requests_total",
 		Help:      "Count of total requests forwarded to TIPS ingress service.",
-	}, []string{
-		"backend_name",
 	})
 
 	backendProbeChecksTotal = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -506,13 +504,11 @@ var (
 		"backend_name",
 	})
 
-	ingressRequestDurationSumm = promauto.NewSummaryVec(prometheus.SummaryOpts{
+	ingressRequestDurationSum = promauto.NewSummary(prometheus.SummaryOpts{
 		Namespace:  MetricsNamespace,
 		Name:       "tips_ingress_request_duration_seconds",
 		Help:       "Summary of TIPS ingress request response times broken down by backend.",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
-	}, []string{
-		"backend_name",
 	})
 )
 
@@ -703,12 +699,12 @@ func RecordBackendProbeDuration(backendName string, duration time.Duration) {
 	backendProbeDurationHist.WithLabelValues(backendName).Observe(duration.Seconds())
 }
 
-func RecordIngressRequest(backendName string) {
-	ingressRequestsTotal.WithLabelValues(backendName).Inc()
+func RecordIngressRequest() {
+	ingressRequestsTotal.Inc()
 }
 
-func RecordIngressRequestDuration(backendName string, duration time.Duration) {
-	ingressRequestDurationSumm.WithLabelValues(backendName).Observe(duration.Seconds())
+func RecordIngressRequestDuration(duration time.Duration) {
+	ingressRequestDurationSum.Observe(duration.Seconds())
 }
 
 func boolToFloat64(b bool) float64 {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -184,7 +184,7 @@ func Start(config *Config) (*Server, func(), error) {
 		if cfg.ProbeURL != "" {
 			opts = append(opts, WithProbe(cfg.ProbeURL, cfg.ProbeFailureThreshold, cfg.ProbeSuccessThreshold, cfg.ProbePeriodSeconds, cfg.ProbeTimeoutSeconds))
 		}
-		
+
 		if cfg.IngressRPC != "" {
 			opts = append(opts, WithIngressRPC(cfg.IngressRPC))
 		}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -184,6 +184,10 @@ func Start(config *Config) (*Server, func(), error) {
 		if cfg.ProbeURL != "" {
 			opts = append(opts, WithProbe(cfg.ProbeURL, cfg.ProbeFailureThreshold, cfg.ProbeSuccessThreshold, cfg.ProbePeriodSeconds, cfg.ProbeTimeoutSeconds))
 		}
+		
+		if cfg.IngressRPC != "" {
+			opts = append(opts, WithIngressRPC(cfg.IngressRPC))
+		}
 
 		headers := map[string]string{}
 		for headerName, headerValue := range cfg.Headers {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -512,6 +512,7 @@ func Start(config *Config) (*Server, func(), error) {
 		apiKeys,
 		config.TxValidationMiddlewareConfig,
 		time.Duration(config.Server.GracefulShutdownSeconds)*time.Second,
+		config.IngressRPC,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -185,10 +185,6 @@ func Start(config *Config) (*Server, func(), error) {
 			opts = append(opts, WithProbe(cfg.ProbeURL, cfg.ProbeFailureThreshold, cfg.ProbeSuccessThreshold, cfg.ProbePeriodSeconds, cfg.ProbeTimeoutSeconds))
 		}
 
-		if cfg.IngressRPC != "" {
-			opts = append(opts, WithIngressRPC(cfg.IngressRPC))
-		}
-
 		headers := map[string]string{}
 		for headerName, headerValue := range cfg.Headers {
 			headerValue, err := ReadFromEnvOrConfig(headerValue)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -263,13 +263,13 @@ func NewServer(
 		txValidationClient:       txValidationClient,
 		txValidationFailOpen:     txValidationFailOpen,
 		gracefulShutdownDuration: gracefulShutdownDuration,
-		ingressRpc:              ingressRpc,
+		ingressRpc:               ingressRpc,
 		ingressRpcClient: &http.Client{
 			Timeout: defaultRPCTimeout,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
-		},		
+		},
 	}, nil
 }
 
@@ -698,7 +698,7 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 						RecordIngressRequestDuration(time.Since(ingressStart))
 					}()
 				}
-			}			
+			}
 		}
 
 		// Apply transaction validation middleware if enabled and method is configured.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Pulls in the latest changes from upstream main into `base/infra-routing:main` and rebases `base/infra-routing:release`

**Tests**

- No logic changes, we're pulling in from upstream 
- I manually verified that the changes from `release` -> `main` remain the same in this PR. https://github.com/base/infra-routing/compare/main...base:infra-routing:release?expand=1 

**Additional context**


**Metadata**

