### PR TITLE
feat: consistent hashing

### DIFF
--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -141,6 +141,37 @@ See `metrics.go` for a list of all available metrics.
 
 The metrics port is configurable via the `metrics.port` and `metrics.host` keys in the config.
 
+## Sender Hash Routing
+
+For `eth_sendRawTransaction` requests, proxyd supports consistent hash-based routing using the transaction sender's address. This ensures transactions from the same sender always route to the same mempool node, improving transaction deduplication and ordering.
+
+To enable sender hash routing:
+
+```toml
+[backend_groups.mempool]
+backends = ["node1", "node2", "node3"]
+routing_strategy = "sender_hash"
+sender_hash_salt = "$SENDER_HASH_SALT"
+```
+
+Configuration:
+* `routing_strategy = "sender_hash"` - Enables sender-based consistent hashing
+* `sender_hash_salt` - A secret salt value used in the hash computation. Supports environment variable syntax (e.g., `$SENDER_HASH_SALT`)
+
+The routing algorithm uses rendezvous (HRW) hashing with SHA256:
+* Computes `SHA256(sender_address + salt + backend_name)` for each backend
+* Routes to the backend with the highest score
+* Unhealthy backends are automatically excluded
+* If the primary backend fails, the request is retried on the next-highest-scoring backend
+
+Security considerations:
+* The salt should be kept secret to prevent prediction attacks
+* Salt rotation should be infrequent to avoid disrupting sender-to-node affinity
+* Use environment variables (e.g., `$SENDER_HASH_SALT`) rather than hardcoding the salt
+
+Non-sendRawTransaction methods use the default fallback routing strategy.
+
+
 ## Adding Backend SSL Certificates in Docker
 
 The Docker image runs on Alpine Linux. If you get SSL errors when connecting to a backend within Docker, you may need to add additional certificates to Alpine's certificate store. To do this, bind mount the certificate bundle into a file in `/usr/local/share/ca-certificates`. The `entrypoint.sh` script will then update the store with whatever is in the `ca-certificates` directory prior to starting `proxyd`.

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1037,6 +1037,10 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 
 	var backends []*Backend
 
+	// Use sender hash routing strategy if it is set and the request is a single sendRawTransaction,
+	// sendRawTransactionConditional, or sendRawTransactionSync request.
+	//
+	// Note: Non-sendRawTransaction requests are not supported by sender hash routing.
 	if bg.routingStrategy == SenderHashRoutingStrategy &&
 		len(rpcReqs) == 1 &&
 		!isBatch &&
@@ -1298,6 +1302,10 @@ func (bg *BackendGroup) orderedBackendsForRequest() []*Backend {
 	}
 }
 
+// orderedBackendsForSenderHash returns the ordered backends for a sender hash routing request.
+// If the sender hash routing strategy is not set or the router is not initialized, it falls back to the default ordering.
+// If the request is not a single sendRawTransaction, sendRawTransactionConditional, or sendRawTransactionSync request, it falls back to the default ordering.
+// If the request is a single sendRawTransaction, sendRawTransactionConditional, or sendRawTransactionSync request, it returns the ordered backends for the sender hash routing.
 func (bg *BackendGroup) orderedBackendsForSenderHash(ctx context.Context, req *RPCReq) []*Backend {
 	if bg.senderHashRouter == nil {
 		log.Warn("sender_hash routing strategy configured but no router initialized, falling back to default ordering",
@@ -1307,6 +1315,7 @@ func (bg *BackendGroup) orderedBackendsForSenderHash(ctx context.Context, req *R
 		return bg.orderedBackendsForRequest()
 	}
 
+	// Get the transaction information
 	tx, err := parseRawTx(req)
 	if err != nil {
 		log.Warn("failed to parse transaction for sender_hash routing, falling back to default ordering",
@@ -1317,6 +1326,7 @@ func (bg *BackendGroup) orderedBackendsForSenderHash(ctx context.Context, req *R
 		return bg.orderedBackendsForRequest()
 	}
 
+	// Get the sender from the transaction to use for consistent routing
 	senderAddr, err := ExtractSenderFromTx(ctx, tx)
 	if err != nil {
 		log.Warn("failed to extract sender for sender_hash routing, falling back to default ordering",
@@ -1327,6 +1337,8 @@ func (bg *BackendGroup) orderedBackendsForSenderHash(ctx context.Context, req *R
 		return bg.orderedBackendsForRequest()
 	}
 
+	// Use the sender address and determine the backends suitable. The ordering
+	// is determine by health followed by the Highest Random Weighted score.
 	backends := bg.senderHashRouter.OrderedBackendsForSender(senderAddr, bg.Backends)
 	if len(backends) == 0 {
 		log.Warn("sender_hash routing returned no backends, falling back to default ordering",

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1041,7 +1041,7 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 	// sendRawTransactionConditional, or sendRawTransactionSync request.
 	//
 	// Note: Non-sendRawTransaction requests are not supported by sender hash routing.
-	if bg.routingStrategy == SenderHashRoutingStrategy &&
+	if bg.GetRoutingStrategy() == SenderHashRoutingStrategy &&
 		len(rpcReqs) == 1 &&
 		!isBatch &&
 		IsSendRawTransactionMethod(rpcReqs[0].Method) {
@@ -1316,7 +1316,7 @@ func (bg *BackendGroup) orderedBackendsForSenderHash(ctx context.Context, req *R
 	}
 
 	// Get the transaction information
-	tx, err := parseRawTx(req)
+	tx, err := ParseRawTx(req)
 	if err != nil {
 		log.Warn("failed to parse transaction for sender_hash routing, falling back to default ordering",
 			"backend_group", bg.Name,

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -481,12 +481,6 @@ func WithIntermittentNetworkErrorSlidingWindow(sw *sw.AvgSlidingWindow) BackendO
 	}
 }
 
-func WithIngressRPC(ingressRPC string) BackendOpt {
-	return func(b *Backend) {
-		b.ingressRPC = ingressRPC
-	}
-}
-
 func WithProbe(probeURL string, probeFailureThreshold int, probeSuccessThreshold int, probePeriodSeconds int, probeTimeoutSeconds int) BackendOpt {
 	return func(b *Backend) {
 		b.probeURL = probeURL

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -481,6 +481,12 @@ func WithIntermittentNetworkErrorSlidingWindow(sw *sw.AvgSlidingWindow) BackendO
 	}
 }
 
+func WithIngressRPC(ingressRPC string) BackendOpt {
+	return func(b *Backend) {
+		b.ingressRPC = ingressRPC
+	}
+}
+
 func WithProbe(probeURL string, probeFailureThreshold int, probeSuccessThreshold int, probePeriodSeconds int, probeTimeoutSeconds int) BackendOpt {
 	return func(b *Backend) {
 		b.probeURL = probeURL
@@ -999,6 +1005,7 @@ type BackendGroup struct {
 	Consensus              *ConsensusPoller
 	FallbackBackends       map[string]bool
 	routingStrategy        RoutingStrategy
+	senderHashRouter       *SenderHashRouter
 	multicallRPCErrorCheck bool
 	maxBlockRange          uint64
 }
@@ -1034,7 +1041,16 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		return nil, "", nil
 	}
 
-	backends := bg.orderedBackendsForRequest()
+	var backends []*Backend
+
+	if bg.routingStrategy == SenderHashRoutingStrategy &&
+		len(rpcReqs) == 1 &&
+		!isBatch &&
+		IsSendRawTransactionMethod(rpcReqs[0].Method) {
+		backends = bg.orderedBackendsForSenderHash(ctx, rpcReqs[0])
+	} else {
+		backends = bg.orderedBackendsForRequest()
+	}
 
 	overriddenResponses := make([]*indexedReqRes, 0)
 	rewrittenReqs := make([]*RPCReq, 0, len(rpcReqs))
@@ -1286,6 +1302,55 @@ func (bg *BackendGroup) orderedBackendsForRequest() []*Backend {
 		}
 		return append(healthy, unhealthy...)
 	}
+}
+
+func (bg *BackendGroup) orderedBackendsForSenderHash(ctx context.Context, req *RPCReq) []*Backend {
+	if bg.senderHashRouter == nil {
+		log.Warn("sender_hash routing strategy configured but no router initialized, falling back to default ordering",
+			"backend_group", bg.Name,
+			"req_id", GetReqID(ctx),
+		)
+		return bg.orderedBackendsForRequest()
+	}
+
+	tx, err := parseRawTx(req)
+	if err != nil {
+		log.Warn("failed to parse transaction for sender_hash routing, falling back to default ordering",
+			"backend_group", bg.Name,
+			"req_id", GetReqID(ctx),
+			"err", err,
+		)
+		return bg.orderedBackendsForRequest()
+	}
+
+	senderAddr, err := ExtractSenderFromTx(ctx, tx)
+	if err != nil {
+		log.Warn("failed to extract sender for sender_hash routing, falling back to default ordering",
+			"backend_group", bg.Name,
+			"req_id", GetReqID(ctx),
+			"err", err,
+		)
+		return bg.orderedBackendsForRequest()
+	}
+
+	backends := bg.senderHashRouter.OrderedBackendsForSender(senderAddr, bg.Backends)
+	if len(backends) == 0 {
+		log.Warn("sender_hash routing returned no backends, falling back to default ordering",
+			"backend_group", bg.Name,
+			"req_id", GetReqID(ctx),
+			"sender", senderAddr.Hex(),
+		)
+		return bg.orderedBackendsForRequest()
+	}
+
+	log.Debug("using sender_hash routing",
+		"backend_group", bg.Name,
+		"req_id", GetReqID(ctx),
+		"sender", senderAddr.Hex(),
+		"primary_backend", backends[0].Name,
+	)
+
+	return backends
 }
 
 func (bg *BackendGroup) loadBalancedConsensusGroup() []*Backend {

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1104,11 +1104,14 @@ func (bg *BackendGroup) forwardWithSenderHashRouting(ctx context.Context, rpcReq
 		}()
 	}
 
+	// Calculate how many goroutine results to collect:
+	// one per sender group + one for defaultReqs (if any)
 	expectedResults := len(senderReqs)
 	if len(defaultReqs) > 0 {
 		expectedResults++
 	}
 
+	// Collect responses from all parallel goroutines
 	var allResponses []*RPCRes
 	var servedBy string
 	for i := 0; i < expectedResults; i++ {

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1035,21 +1035,6 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		return nil, "", nil
 	}
 
-	var backends []*Backend
-
-	// Use sender hash routing strategy if it is set and the request is a single sendRawTransaction,
-	// sendRawTransactionConditional, or sendRawTransactionSync request.
-	//
-	// Note: Non-sendRawTransaction requests are not supported by sender hash routing.
-	if bg.GetRoutingStrategy() == SenderHashRoutingStrategy &&
-		len(rpcReqs) == 1 &&
-		!isBatch &&
-		IsSendRawTransactionMethod(rpcReqs[0].Method) {
-		backends = bg.orderedBackendsForSenderHash(ctx, rpcReqs[0])
-	} else {
-		backends = bg.orderedBackendsForRequest()
-	}
-
 	overriddenResponses := make([]*indexedReqRes, 0)
 	rewrittenReqs := make([]*RPCReq, 0, len(rpcReqs))
 
@@ -1071,6 +1056,83 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		return backendResp.RPCRes, backendResp.ServedBy, backendResp.error
 	}
 
+	// For sender_hash routing, split batch by sender and forward to appropriate backends
+	if bg.GetRoutingStrategy() == SenderHashRoutingStrategy && bg.senderHashRouter != nil {
+		return bg.forwardWithSenderHashRouting(ctx, rpcReqs, isBatch, overriddenResponses)
+	}
+
+	backends := bg.orderedBackendsForRequest()
+	return bg.forwardToBackends(ctx, rpcReqs, backends, isBatch, overriddenResponses)
+}
+
+// forwardWithSenderHashRouting handles sender_hash routing for both single requests and batches.
+func (bg *BackendGroup) forwardWithSenderHashRouting(ctx context.Context, rpcReqs []*RPCReq, isBatch bool, overriddenResponses []*indexedReqRes) ([]*RPCRes, string, error) {
+	senderReqs, defaultReqs := bg.senderHashRouter.SplitBatchBySender(ctx, rpcReqs)
+
+	if len(senderReqs) == 0 {
+		backends := bg.orderedBackendsForRequest()
+		return bg.forwardToBackends(ctx, rpcReqs, backends, isBatch, overriddenResponses)
+	}
+
+	type result struct {
+		responses []*RPCRes
+		servedBy  string
+		err       error
+	}
+	resultCh := make(chan result, len(senderReqs)+1)
+
+	// For all sendRawTransaction requests, route to the appropriate backend based on the sender hash
+	for sender, reqs := range senderReqs {
+		go func(s common.Address, r []*RPCReq) {
+			// Get the available ordered backends based on the sender hash
+			backends := bg.senderHashRouter.OrderedBackendsForSender(s, bg.Backends)
+
+			// Forward the requests to the appropriate backend
+			res, servedBy, err := bg.forwardToBackends(ctx, r, backends, len(r) > 1, nil)
+			resultCh <- result{res, servedBy, err}
+		}(sender, reqs)
+	}
+
+	// All other requests don't use consistent hashing ordering
+	//
+	// NOTE: It is possible that other requests are routed to the same backend as the sender requests.
+	if len(defaultReqs) > 0 {
+		go func() {
+			backends := bg.orderedBackendsForRequest()
+			res, servedBy, err := bg.forwardToBackends(ctx, defaultReqs, backends, len(defaultReqs) > 1, nil)
+			resultCh <- result{res, servedBy, err}
+		}()
+	}
+
+	expectedResults := len(senderReqs)
+	if len(defaultReqs) > 0 {
+		expectedResults++
+	}
+
+	var allResponses []*RPCRes
+	var servedBy string
+	for i := 0; i < expectedResults; i++ {
+		r := <-resultCh
+		if r.err != nil {
+			log.Error("error in sender_hash batch forward",
+				"req_id", GetReqID(ctx),
+				"err", r.err,
+			)
+			continue
+		}
+		allResponses = append(allResponses, r.responses...)
+		if servedBy == "" {
+			servedBy = r.servedBy
+		}
+	}
+
+	res := OverrideResponses(allResponses, overriddenResponses)
+	sortBatchRPCResponse(rpcReqs, res)
+	return res, servedBy, nil
+}
+
+// forwardToBackends forwards requests to the given backends and returns the response.
+func (bg *BackendGroup) forwardToBackends(ctx context.Context, rpcReqs []*RPCReq, backends []*Backend, isBatch bool, overriddenResponses []*indexedReqRes) ([]*RPCRes, string, error) {
 	ch := make(chan BackendGroupRPCResponse)
 	go func() {
 		defer close(ch)
@@ -1300,63 +1362,6 @@ func (bg *BackendGroup) orderedBackendsForRequest() []*Backend {
 		}
 		return append(healthy, unhealthy...)
 	}
-}
-
-// orderedBackendsForSenderHash returns the ordered backends for a sender hash routing request.
-// If the sender hash routing strategy is not set or the router is not initialized, it falls back to the default ordering.
-// If the request is not a single sendRawTransaction, sendRawTransactionConditional, or sendRawTransactionSync request, it falls back to the default ordering.
-// If the request is a single sendRawTransaction, sendRawTransactionConditional, or sendRawTransactionSync request, it returns the ordered backends for the sender hash routing.
-func (bg *BackendGroup) orderedBackendsForSenderHash(ctx context.Context, req *RPCReq) []*Backend {
-	if bg.senderHashRouter == nil {
-		log.Warn("sender_hash routing strategy configured but no router initialized, falling back to default ordering",
-			"backend_group", bg.Name,
-			"req_id", GetReqID(ctx),
-		)
-		return bg.orderedBackendsForRequest()
-	}
-
-	// Get the transaction information
-	tx, err := ParseRawTx(req)
-	if err != nil {
-		log.Warn("failed to parse transaction for sender_hash routing, falling back to default ordering",
-			"backend_group", bg.Name,
-			"req_id", GetReqID(ctx),
-			"err", err,
-		)
-		return bg.orderedBackendsForRequest()
-	}
-
-	// Get the sender from the transaction to use for consistent routing
-	senderAddr, err := ExtractSenderFromTx(ctx, tx)
-	if err != nil {
-		log.Warn("failed to extract sender for sender_hash routing, falling back to default ordering",
-			"backend_group", bg.Name,
-			"req_id", GetReqID(ctx),
-			"err", err,
-		)
-		return bg.orderedBackendsForRequest()
-	}
-
-	// Use the sender address and determine the backends suitable. The ordering
-	// is determine by health followed by the Highest Random Weighted score.
-	backends := bg.senderHashRouter.OrderedBackendsForSender(senderAddr, bg.Backends)
-	if len(backends) == 0 {
-		log.Warn("sender_hash routing returned no backends, falling back to default ordering",
-			"backend_group", bg.Name,
-			"req_id", GetReqID(ctx),
-			"sender", senderAddr.Hex(),
-		)
-		return bg.orderedBackendsForRequest()
-	}
-
-	log.Debug("using sender_hash routing",
-		"backend_group", bg.Name,
-		"req_id", GetReqID(ctx),
-		"sender", senderAddr.Hex(),
-		"primary_backend", backends[0].Name,
-	)
-
-	return backends
 }
 
 func (bg *BackendGroup) loadBalancedConsensusGroup() []*Backend {

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -2,7 +2,6 @@ package proxyd
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -211,67 +210,6 @@ func TestAllowedStatusCodes(t *testing.T) {
 	require.Equal(t, -32000, res[0].Error.Code)
 	require.Equal(t, "backend has a foo problem", res[0].Error.Message)
 	require.Equal(t, http.StatusServiceUnavailable, res[0].Error.HTTPErrorCode)
-}
-
-func TestIngressForwarding(t *testing.T) {
-	backendRequests := make(chan []byte, 10)
-	ingressRequests := make(chan []byte, 10)
-
-	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		backendRequests <- body
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":"0x1234","id":1}`))
-	}))
-	defer backendServer.Close()
-
-	ingressServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		ingressRequests <- body
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":"ok","id":1}`))
-	}))
-	defer ingressServer.Close()
-
-	backend := NewBackend(
-		"test-backend",
-		backendServer.URL,
-		"",
-		semaphore.NewWeighted(10),
-		WithIngressRPC(ingressServer.URL),
-	)
-
-	rpcReq := &RPCReq{
-		JSONRPC: "2.0",
-		Method:  "eth_blockNumber",
-		Params:  []byte(`[]`),
-		ID:      []byte(`1`),
-	}
-
-	ctx := context.Background()
-	res, err := backend.Forward(ctx, []*RPCReq{rpcReq}, false)
-
-	require.NoError(t, err)
-	require.Len(t, res, 1)
-	require.False(t, res[0].IsError())
-
-	select {
-	case backendBody := <-backendRequests:
-		require.Contains(t, string(backendBody), "eth_blockNumber")
-		require.Contains(t, string(backendBody), `"id":1`)
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Backend did not receive request")
-	}
-
-	select {
-	case ingressBody := <-ingressRequests:
-		require.Contains(t, string(ingressBody), "eth_blockNumber")
-		require.Contains(t, string(ingressBody), `"id":1`)
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("Ingress did not receive request")
-	}
 }
 
 func getHttpResponseCodeCount(statusCode string) float64 {

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -141,6 +141,7 @@ func TestClientDisconnectionFlow499(t *testing.T) {
 		nil,                                    // limExemptKeys
 		TxValidationMiddlewareConfig{},         // txValidationConfig
 		10*time.Second,                         // gracefulShutdownDuration
+		"",                                     // ingressRpc
 	)
 	require.NoError(t, err)
 
@@ -216,7 +217,6 @@ func TestIngressForwarding(t *testing.T) {
 	backendRequests := make(chan []byte, 10)
 	ingressRequests := make(chan []byte, 10)
 
-	// Mock backend server
 	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		backendRequests <- body
@@ -226,7 +226,6 @@ func TestIngressForwarding(t *testing.T) {
 	}))
 	defer backendServer.Close()
 
-	// Mock ingress server
 	ingressServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		ingressRequests <- body
@@ -236,7 +235,6 @@ func TestIngressForwarding(t *testing.T) {
 	}))
 	defer ingressServer.Close()
 
-	// Create backend with ingress RPC configured
 	backend := NewBackend(
 		"test-backend",
 		backendServer.URL,
@@ -245,7 +243,6 @@ func TestIngressForwarding(t *testing.T) {
 		WithIngressRPC(ingressServer.URL),
 	)
 
-	// Create a test RPC request
 	rpcReq := &RPCReq{
 		JSONRPC: "2.0",
 		Method:  "eth_blockNumber",
@@ -253,16 +250,13 @@ func TestIngressForwarding(t *testing.T) {
 		ID:      []byte(`1`),
 	}
 
-	// Forward the request
 	ctx := context.Background()
 	res, err := backend.Forward(ctx, []*RPCReq{rpcReq}, false)
 
-	// Verify the backend request was successful
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	require.False(t, res[0].IsError())
 
-	// Verify both backend and ingress received the request
 	select {
 	case backendBody := <-backendRequests:
 		require.Contains(t, string(backendBody), "eth_blockNumber")
@@ -271,7 +265,6 @@ func TestIngressForwarding(t *testing.T) {
 		t.Fatal("Backend did not receive request")
 	}
 
-	// Give a bit more time for the async ingress request to complete
 	select {
 	case ingressBody := <-ingressRequests:
 		require.Contains(t, string(ingressBody), "eth_blockNumber")

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -164,6 +164,11 @@ func (b *BackendGroupConfig) ValidateRoutingStrategy(bgName string) bool {
 		return true
 	case FallbackRoutingStrategy:
 		return true
+	case SenderHashRoutingStrategy:
+		if b.SenderHashSalt == "" {
+			log.Warn("sender_hash routing strategy requires sender_hash_salt to be set", "name", bgName)
+		}
+		return true
 	case "":
 		log.Info("Empty routing strategy provided for backend_group, using fallback strategy ", "name", bgName)
 		b.RoutingStrategy = FallbackRoutingStrategy
@@ -177,6 +182,7 @@ const (
 	ConsensusAwareRoutingStrategy RoutingStrategy = "consensus_aware"
 	MulticallRoutingStrategy      RoutingStrategy = "multicall"
 	FallbackRoutingStrategy       RoutingStrategy = "fallback"
+	SenderHashRoutingStrategy     RoutingStrategy = "sender_hash"
 )
 
 type BackendGroupConfig struct {
@@ -185,6 +191,12 @@ type BackendGroupConfig struct {
 	WeightedRouting bool `toml:"weighted_routing"`
 
 	RoutingStrategy RoutingStrategy `toml:"routing_strategy"`
+
+	// SenderHashSalt is a secret salt used for consistent hash-based routing.
+	// When routing_strategy is "sender_hash", this salt is combined with the
+	// sender address to determine which backend receives the transaction.
+	// Use an environment variable (e.g., "$SENDER_HASH_SALT") to keep it secret.
+	SenderHashSalt string `toml:"sender_hash_salt"`
 
 	MulticallRPCErrorCheck bool `toml:"multicall_rpc_error_check"`
 

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -116,6 +116,13 @@ backends = ["infura"]
 [backend_groups.alchemy]
 backends = ["alchemy"]
 
+# Example: Sender hash routing for mempool nodes
+# Routes eth_sendRawTransaction requests to consistent backends based on sender address
+# [backend_groups.mempool]
+# backends = ["mempool1", "mempool2", "mempool3"]
+# routing_strategy = "sender_hash"
+# sender_hash_salt = "$SENDER_HASH_SALT"
+
 # If the authentication group below is in the config,
 # proxyd will only accept authenticated requests.
 [authentication]

--- a/proxyd/integration_tests/sender_hash_routing_test.go
+++ b/proxyd/integration_tests/sender_hash_routing_test.go
@@ -28,17 +28,20 @@ const senderHashTxHex2 = "0x02f8758201a48217fd84773594008504a817c80082520894be53
 const senderHashTxAccepted = `{"jsonrpc": "2.0","result": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","id": 1}`
 const senderHashDummyRes = `{"id": 123, "jsonrpc": "2.0", "result": "dummy"}`
 
+// trackingBackend is a backend that tracks the number of requests it has served.
 type trackingBackend struct {
 	*MockBackend
 	requestCount int32
 }
 
+// newTrackingBackend creates a new tracking backend with the given handler.
 func newTrackingBackend(handler http.Handler) *trackingBackend {
 	return &trackingBackend{
 		MockBackend: NewMockBackend(handler),
 	}
 }
 
+// Handler returns a handler that tracks the number of requests it has served.
 func (t *trackingBackend) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&t.requestCount, 1)
@@ -47,10 +50,12 @@ func (t *trackingBackend) Handler() http.Handler {
 	})
 }
 
+// GetRequestCount returns the number of requests it has served.
 func (t *trackingBackend) GetRequestCount() int {
 	return int(atomic.LoadInt32(&t.requestCount))
 }
 
+// ResetRequestCount resets the number of requests it has served.
 func (t *trackingBackend) ResetRequestCount() {
 	atomic.StoreInt32(&t.requestCount, 0)
 }
@@ -105,6 +110,7 @@ func TestSenderHashRouting(t *testing.T) {
 		nodes, _, svr, shutdown := setupSenderHash(t)
 		defer shutdown()
 
+		// Send 5 requests from the same sender to proxyd.
 		for i := 0; i < 5; i++ {
 			body := makeSenderHashRawTx(senderHashTxHex1)
 			req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
@@ -117,20 +123,20 @@ func TestSenderHashRouting(t *testing.T) {
 			require.Equal(t, 200, resp.StatusCode)
 		}
 
-		totalRequests := 0
-		for _, node := range nodes {
-			totalRequests += node.GetRequestCount()
-		}
-		require.Equal(t, 5, totalRequests)
-
-		receivingBackends := 0
-		for _, node := range nodes {
-			if node.GetRequestCount() > 0 {
-				receivingBackends++
-				require.Equal(t, 5, node.GetRequestCount())
+		var receivingNode string
+		for name, node := range nodes {
+			count := node.GetRequestCount()
+			// If there was a request, then that backend should have received all 5 requests.
+			if count > 0 {
+				require.Equal(t, 5, count, "receiving backend should get all 5 requests")
+				require.Empty(t, receivingNode, "only one backend should receive requests")
+				receivingNode = name
+			} else {
+				// All other backends should get zero requests.
+				require.Equal(t, 0, count, "non-receiving backends should get zero requests")
 			}
 		}
-		require.Equal(t, 1, receivingBackends, "All requests from same sender should go to exactly one backend")
+		require.NotEmpty(t, receivingNode, "one backend should have received all requests")
 	})
 
 	t.Run("Different senders can route to different backends", func(t *testing.T) {
@@ -159,14 +165,23 @@ func TestSenderHashRouting(t *testing.T) {
 		require.Equal(t, 200, resp2.StatusCode)
 		servedBy2 := resp2.Header.Get("X-Served-By")
 
-		totalRequests := 0
-		for _, node := range nodes {
-			totalRequests += node.GetRequestCount()
-		}
-		require.Equal(t, 2, totalRequests)
-
 		require.NotEmpty(t, servedBy1)
 		require.NotEmpty(t, servedBy2)
+		require.NotEqual(t, servedBy1, servedBy2, "different senders should route to different backends")
+
+		totalRequests := 0
+		backendsWithRequests := 0
+		for _, node := range nodes {
+			count := node.GetRequestCount()
+			totalRequests += count
+			// Since we only sent 1 request per sender, each backend should have received exactly 1 request.
+			if count > 0 {
+				backendsWithRequests++
+				require.Equal(t, 1, count, "each backend should receive exactly 1 request")
+			}
+		}
+		require.Equal(t, 2, totalRequests, "total requests should be 2")
+		require.Equal(t, 2, backendsWithRequests, "exactly 2 backends should have received requests")
 	})
 
 	t.Run("Non-sendRawTransaction uses fallback routing", func(t *testing.T) {
@@ -190,38 +205,6 @@ func TestSenderHashRouting(t *testing.T) {
 		rpcRes := &proxyd.RPCRes{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
 		require.False(t, rpcRes.IsError())
-	})
-
-	t.Run("Routing is deterministic with same salt", func(t *testing.T) {
-		nodes, _, svr, shutdown := setupSenderHash(t)
-		defer shutdown()
-
-		var firstServedBy string
-
-		for i := 0; i < 10; i++ {
-			body := makeSenderHashRawTx(senderHashTxHex1)
-			req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
-			req.Header.Set("X-Forwarded-For", "203.0.113.1")
-			rr := httptest.NewRecorder()
-			svr.HandleRPC(rr, req)
-
-			resp := rr.Result()
-			servedBy := resp.Header.Get("X-Served-By")
-			resp.Body.Close()
-
-			if i == 0 {
-				firstServedBy = servedBy
-			} else {
-				require.Equal(t, firstServedBy, servedBy, "Same sender should always route to same backend")
-			}
-		}
-
-		for _, node := range nodes {
-			count := node.GetRequestCount()
-			if count > 0 {
-				require.Equal(t, 10, count)
-			}
-		}
 	})
 
 	t.Run("Returns success when transaction is accepted", func(t *testing.T) {
@@ -287,7 +270,11 @@ func TestSenderHashRoutingFailover(t *testing.T) {
 		resp2 := rr2.Result()
 		defer resp2.Body.Close()
 
-		require.NotNil(t, resp2.Body)
+		secondaryServedBy := resp2.Header.Get("X-Served-By")
+		require.NotEmpty(t, secondaryServedBy)
+		require.NotEqual(t, primaryServedBy, secondaryServedBy, "after primary returns error, request should route to a different backend")
+
+		require.Equal(t, 200, resp2.StatusCode)
 		require.Equal(t, 3, len(bg.Backends))
 	})
 }

--- a/proxyd/integration_tests/sender_hash_routing_test.go
+++ b/proxyd/integration_tests/sender_hash_routing_test.go
@@ -3,6 +3,7 @@ package integration_tests
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -42,9 +43,50 @@ func newTrackingBackend(handler http.Handler) *trackingBackend {
 }
 
 // Handler returns a handler that tracks the number of requests it has served.
+// It detects batch requests and returns a proper batch response.
 func (t *trackingBackend) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&t.requestCount, 1)
+
+		// Read the request body to detect if it's a batch
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+		defer r.Body.Close()
+
+		// Check if it's a batch request (starts with '[')
+		trimmed := bytes.TrimSpace(body)
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			// Parse the batch to get the IDs
+			var reqs []json.RawMessage
+			if err := json.Unmarshal(trimmed, &reqs); err != nil {
+				w.WriteHeader(500)
+				return
+			}
+
+			// Build batch response with matching IDs
+			var responses []map[string]interface{}
+			for _, req := range reqs {
+				var r map[string]interface{}
+				if err := json.Unmarshal(req, &r); err != nil {
+					continue
+				}
+				responses = append(responses, map[string]interface{}{
+					"jsonrpc": "2.0",
+					"result":  "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+					"id":      r["id"],
+				})
+			}
+
+			w.WriteHeader(200)
+			respBytes, _ := json.Marshal(responses)
+			_, _ = w.Write(respBytes)
+			return
+		}
+
+		// Single request
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(senderHashTxAccepted))
 	})
@@ -232,6 +274,126 @@ func TestSenderHashRouting(t *testing.T) {
 			totalRequests += node.GetRequestCount()
 		}
 		require.Equal(t, 1, totalRequests)
+	})
+}
+
+func TestSenderHashRoutingBatch(t *testing.T) {
+	t.Run("Batch with multiple senders routes to different backends", func(t *testing.T) {
+		nodes, _, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		// batch with 2 different senders
+		batch := `[
+			{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["` + senderHashTxHex1 + `"],"id":1},
+			{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["` + senderHashTxHex2 + `"],"id":2}
+		]`
+
+		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader([]byte(batch)))
+		req.Header.Set("X-Forwarded-For", "203.0.113.1")
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		svr.HandleRPC(rr, req)
+
+		resp := rr.Result()
+		defer resp.Body.Close()
+		require.Equal(t, 200, resp.StatusCode)
+
+		var rpcRes []*proxyd.RPCRes
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&rpcRes))
+		require.Len(t, rpcRes, 2)
+
+		backendsWithRequests := 0
+		totalRequests := 0
+		for _, node := range nodes {
+			count := node.GetRequestCount()
+			totalRequests += count
+			// If the backend received any requests, it should have received exactly 1 request.
+			if count > 0 {
+				require.Equal(t, 1, count, "each backend should receive exactly 1 request")
+				backendsWithRequests++
+			}
+		}
+		require.Equal(t, 2, totalRequests, "total requests should be 2")
+		require.Equal(t, 2, backendsWithRequests, "exactly 2 backends should receive requests")
+	})
+
+	t.Run("Batch with same sender routes to single backend", func(t *testing.T) {
+		nodes, _, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		// batch with 3 requests from the same sender
+		batch := `[
+			{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["` + senderHashTxHex1 + `"],"id":1},
+			{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["` + senderHashTxHex1 + `"],"id":2},
+			{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["` + senderHashTxHex1 + `"],"id":3}
+		]`
+
+		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader([]byte(batch)))
+		req.Header.Set("X-Forwarded-For", "203.0.113.1")
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		svr.HandleRPC(rr, req)
+
+		resp := rr.Result()
+		defer resp.Body.Close()
+		require.Equal(t, 200, resp.StatusCode)
+
+		var rpcRes []*proxyd.RPCRes
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&rpcRes))
+		require.Len(t, rpcRes, 3)
+
+		backendsWithRequests := 0
+		totalRequests := 0
+		for _, node := range nodes {
+			count := node.GetRequestCount()
+			totalRequests += count
+			if count > 0 {
+				require.Equal(t, 1, count, "receiving backend should get exactly 1 batch request")
+				backendsWithRequests++
+			}
+		}
+		require.Equal(t, 1, totalRequests, "total requests should be 1 (single batch)")
+		require.Equal(t, 1, backendsWithRequests, "exactly 1 backend should receive the batch")
+	})
+
+	t.Run("Batch with mixed methods splits correctly", func(t *testing.T) {
+		nodes, _, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		// batch with 3 requests, 1 sender-routed, 1 default, 1 sender-routed
+		batch := `[
+			{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["` + senderHashTxHex1 + `"],"id":1},
+			{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0x1234567890123456789012345678901234567890"},"latest"],"id":2},
+			{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["` + senderHashTxHex2 + `"],"id":3}
+		]`
+
+		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader([]byte(batch)))
+		req.Header.Set("X-Forwarded-For", "203.0.113.1")
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		svr.HandleRPC(rr, req)
+
+		resp := rr.Result()
+		defer resp.Body.Close()
+		require.Equal(t, 200, resp.StatusCode)
+
+		var rpcRes []*proxyd.RPCRes
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&rpcRes))
+		require.Len(t, rpcRes, 3)
+
+		backendsWithRequests := 0
+		totalRequests := 0
+		for _, node := range nodes {
+			count := node.GetRequestCount()
+			totalRequests += count
+			if count > 0 {
+				backendsWithRequests++
+			}
+		}
+		// total requests should be 3 (2 sender-routed + 1 default)
+		// at least 2 backends should receive requests (2 different senders)
+		require.Equal(t, 3, totalRequests, "total requests should be 3 (2 sender-routed + 1 default)")
+		require.GreaterOrEqual(t, backendsWithRequests, 2, "at least 2 backends should receive requests (2 different senders)")
 	})
 }
 

--- a/proxyd/integration_tests/sender_hash_routing_test.go
+++ b/proxyd/integration_tests/sender_hash_routing_test.go
@@ -1,0 +1,293 @@
+package integration_tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/stretchr/testify/require"
+)
+
+const senderHashTxHex1 = "0x02f8b28201a406849502f931849502f931830147f9948f3ddd0fbf3e78ca1d6c" +
+	"d17379ed88e261249b5280b84447e7ef2400000000000000000000000089c8b1" +
+	"b2774201bac50f627403eac1b732459cf7000000000000000000000000000000" +
+	"0000000000000000056bc75e2d63100000c080a0473c95566026c312c9664cd6" +
+	"1145d2f3e759d49209fe96011ac012884ec5b017a0763b58f6fa6096e6ba28ee" +
+	"08bfac58f58fb3b8bcef5af98578bdeaddf40bde42"
+
+const senderHashTxHex2 = "0x02f8758201a48217fd84773594008504a817c80082520894be53e587975603" +
+	"a13d0923d0aa6d37c5233dd750865af3107a400080c080a04aefbd5819c35729" +
+	"138fe26b6ae1783ebf08d249b356c2f920345db97877f3f7a008d5ae92560a3c" +
+	"65f723439887205713af7ce7d7f6b24fba198f2afa03435867"
+
+const senderHashTxAccepted = `{"jsonrpc": "2.0","result": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","id": 1}`
+const senderHashDummyRes = `{"id": 123, "jsonrpc": "2.0", "result": "dummy"}`
+
+type trackingBackend struct {
+	*MockBackend
+	requestCount int32
+}
+
+func newTrackingBackend(handler http.Handler) *trackingBackend {
+	return &trackingBackend{
+		MockBackend: NewMockBackend(handler),
+	}
+}
+
+func (t *trackingBackend) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&t.requestCount, 1)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(senderHashTxAccepted))
+	})
+}
+
+func (t *trackingBackend) GetRequestCount() int {
+	return int(atomic.LoadInt32(&t.requestCount))
+}
+
+func (t *trackingBackend) ResetRequestCount() {
+	atomic.StoreInt32(&t.requestCount, 0)
+}
+
+func setupSenderHash(t *testing.T) (map[string]*trackingBackend, *proxyd.BackendGroup, *proxyd.Server, func()) {
+	node1 := newTrackingBackend(nil)
+	node2 := newTrackingBackend(nil)
+	node3 := newTrackingBackend(nil)
+
+	node1.SetHandler(node1.Handler())
+	node2.SetHandler(node2.Handler())
+	node3.SetHandler(node3.Handler())
+
+	require.NoError(t, os.Setenv("NODE1_URL", node1.URL()))
+	require.NoError(t, os.Setenv("NODE2_URL", node2.URL()))
+	require.NoError(t, os.Setenv("NODE3_URL", node3.URL()))
+	require.NoError(t, os.Setenv("SENDER_HASH_SALT", "test-salt-12345"))
+
+	config := ReadConfig("sender_hash")
+	svr, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+
+	bg := svr.BackendGroups["node"]
+	require.NotNil(t, bg)
+	require.Equal(t, 3, len(bg.Backends))
+	require.Equal(t, proxyd.SenderHashRoutingStrategy, bg.GetRoutingStrategy())
+
+	nodes := map[string]*trackingBackend{
+		"node1": node1,
+		"node2": node2,
+		"node3": node3,
+	}
+
+	return nodes, bg, svr, func() {
+		shutdown()
+		node1.Close()
+		node2.Close()
+		node3.Close()
+	}
+}
+
+func makeSenderHashRawTx(dataHex string) []byte {
+	return []byte(`{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["` + dataHex + `"],"id":1}`)
+}
+
+func makeEthCall() []byte {
+	return []byte(`{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0x1234567890123456789012345678901234567890","data":"0x"},"latest"],"id":1}`)
+}
+
+func TestSenderHashRouting(t *testing.T) {
+	t.Run("Same sender routes to same backend deterministically", func(t *testing.T) {
+		nodes, _, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		for i := 0; i < 5; i++ {
+			body := makeSenderHashRawTx(senderHashTxHex1)
+			req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
+			req.Header.Set("X-Forwarded-For", "203.0.113.1")
+			rr := httptest.NewRecorder()
+			svr.HandleRPC(rr, req)
+
+			resp := rr.Result()
+			defer resp.Body.Close()
+			require.Equal(t, 200, resp.StatusCode)
+		}
+
+		totalRequests := 0
+		for _, node := range nodes {
+			totalRequests += node.GetRequestCount()
+		}
+		require.Equal(t, 5, totalRequests)
+
+		receivingBackends := 0
+		for _, node := range nodes {
+			if node.GetRequestCount() > 0 {
+				receivingBackends++
+				require.Equal(t, 5, node.GetRequestCount())
+			}
+		}
+		require.Equal(t, 1, receivingBackends, "All requests from same sender should go to exactly one backend")
+	})
+
+	t.Run("Different senders can route to different backends", func(t *testing.T) {
+		nodes, _, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		body1 := makeSenderHashRawTx(senderHashTxHex1)
+		req1, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body1))
+		req1.Header.Set("X-Forwarded-For", "203.0.113.1")
+		rr1 := httptest.NewRecorder()
+		svr.HandleRPC(rr1, req1)
+
+		resp1 := rr1.Result()
+		defer resp1.Body.Close()
+		require.Equal(t, 200, resp1.StatusCode)
+		servedBy1 := resp1.Header.Get("X-Served-By")
+
+		body2 := makeSenderHashRawTx(senderHashTxHex2)
+		req2, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body2))
+		req2.Header.Set("X-Forwarded-For", "203.0.113.2")
+		rr2 := httptest.NewRecorder()
+		svr.HandleRPC(rr2, req2)
+
+		resp2 := rr2.Result()
+		defer resp2.Body.Close()
+		require.Equal(t, 200, resp2.StatusCode)
+		servedBy2 := resp2.Header.Get("X-Served-By")
+
+		totalRequests := 0
+		for _, node := range nodes {
+			totalRequests += node.GetRequestCount()
+		}
+		require.Equal(t, 2, totalRequests)
+
+		require.NotEmpty(t, servedBy1)
+		require.NotEmpty(t, servedBy2)
+	})
+
+	t.Run("Non-sendRawTransaction uses fallback routing", func(t *testing.T) {
+		nodes, _, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		for _, node := range nodes {
+			node.SetHandler(SingleResponseHandler(200, senderHashDummyRes))
+		}
+
+		body := makeEthCall()
+		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
+		req.Header.Set("X-Forwarded-For", "203.0.113.1")
+		rr := httptest.NewRecorder()
+		svr.HandleRPC(rr, req)
+
+		resp := rr.Result()
+		defer resp.Body.Close()
+		require.Equal(t, 200, resp.StatusCode)
+
+		rpcRes := &proxyd.RPCRes{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
+		require.False(t, rpcRes.IsError())
+	})
+
+	t.Run("Routing is deterministic with same salt", func(t *testing.T) {
+		nodes, _, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		var firstServedBy string
+
+		for i := 0; i < 10; i++ {
+			body := makeSenderHashRawTx(senderHashTxHex1)
+			req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
+			req.Header.Set("X-Forwarded-For", "203.0.113.1")
+			rr := httptest.NewRecorder()
+			svr.HandleRPC(rr, req)
+
+			resp := rr.Result()
+			servedBy := resp.Header.Get("X-Served-By")
+			resp.Body.Close()
+
+			if i == 0 {
+				firstServedBy = servedBy
+			} else {
+				require.Equal(t, firstServedBy, servedBy, "Same sender should always route to same backend")
+			}
+		}
+
+		for _, node := range nodes {
+			count := node.GetRequestCount()
+			if count > 0 {
+				require.Equal(t, 10, count)
+			}
+		}
+	})
+
+	t.Run("Returns success when transaction is accepted", func(t *testing.T) {
+		nodes, _, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		body := makeSenderHashRawTx(senderHashTxHex1)
+		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
+		req.Header.Set("X-Forwarded-For", "203.0.113.1")
+		rr := httptest.NewRecorder()
+		svr.HandleRPC(rr, req)
+
+		resp := rr.Result()
+		defer resp.Body.Close()
+
+		require.Equal(t, 200, resp.StatusCode)
+
+		rpcRes := &proxyd.RPCRes{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
+		require.False(t, rpcRes.IsError())
+		require.NotNil(t, rpcRes.Result)
+
+		totalRequests := 0
+		for _, node := range nodes {
+			totalRequests += node.GetRequestCount()
+		}
+		require.Equal(t, 1, totalRequests)
+	})
+}
+
+func TestSenderHashRoutingFailover(t *testing.T) {
+	t.Run("Routes to next backend when primary returns error", func(t *testing.T) {
+		nodes, bg, svr, shutdown := setupSenderHash(t)
+		defer shutdown()
+
+		body := makeSenderHashRawTx(senderHashTxHex1)
+		req, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body))
+		req.Header.Set("X-Forwarded-For", "203.0.113.1")
+		rr := httptest.NewRecorder()
+		svr.HandleRPC(rr, req)
+
+		resp := rr.Result()
+		primaryServedBy := resp.Header.Get("X-Served-By")
+		resp.Body.Close()
+		require.NotEmpty(t, primaryServedBy)
+
+		for _, node := range nodes {
+			node.ResetRequestCount()
+		}
+
+		for name, node := range nodes {
+			if "node/"+name == primaryServedBy {
+				node.SetHandler(SingleResponseHandler(500, `{"error": "internal error"}`))
+			}
+		}
+
+		body2 := makeSenderHashRawTx(senderHashTxHex1)
+		req2, _ := http.NewRequest("POST", "https://1.1.1.1:8080", bytes.NewReader(body2))
+		req2.Header.Set("X-Forwarded-For", "203.0.113.1")
+		rr2 := httptest.NewRecorder()
+		svr.HandleRPC(rr2, req2)
+
+		resp2 := rr2.Result()
+		defer resp2.Body.Close()
+
+		require.NotNil(t, resp2.Body)
+		require.Equal(t, 3, len(bg.Backends))
+	})
+}

--- a/proxyd/integration_tests/testdata/sender_hash.toml
+++ b/proxyd/integration_tests/testdata/sender_hash.toml
@@ -1,0 +1,28 @@
+[server]
+rpc_port = 8545
+enable_served_by_header = true
+timeout_seconds = 7
+
+[backend]
+response_timeout_seconds = 4
+max_degraded_latency_threshold = "30ms"
+
+[backends]
+[backends.node1]
+rpc_url = "$NODE1_URL"
+
+[backends.node2]
+rpc_url = "$NODE2_URL"
+
+[backends.node3]
+rpc_url = "$NODE3_URL"
+
+[backend_groups]
+[backend_groups.node]
+backends = ["node1", "node2", "node3"]
+routing_strategy = "sender_hash"
+sender_hash_salt = "$SENDER_HASH_SALT"
+
+[rpc_method_mappings]
+eth_call = "node"
+eth_sendRawTransaction = "node"

--- a/proxyd/integration_tests/testdata/sender_hash.toml
+++ b/proxyd/integration_tests/testdata/sender_hash.toml
@@ -1,10 +1,10 @@
 [server]
 rpc_port = 8545
 enable_served_by_header = true
-timeout_seconds = 7
+timeout_seconds = 2
 
 [backend]
-response_timeout_seconds = 4
+response_timeout_seconds = 1
 max_degraded_latency_threshold = "30ms"
 
 [backends]

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -368,6 +368,8 @@ func Start(config *Config) (*Server, func(), error) {
 			maxBlockRange = bg.MaxBlockRange
 		}
 
+		// Verify that the salt is set for sender hash routing strategy.
+		// If the salt is not set, it will fall back to the default ordering.
 		var senderHashRouter *SenderHashRouter
 		if bg.RoutingStrategy == SenderHashRoutingStrategy {
 			salt, err := ReadFromEnvOrConfig(bg.SenderHashSalt)

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -368,12 +368,26 @@ func Start(config *Config) (*Server, func(), error) {
 			maxBlockRange = bg.MaxBlockRange
 		}
 
+		var senderHashRouter *SenderHashRouter
+		if bg.RoutingStrategy == SenderHashRoutingStrategy {
+			salt, err := ReadFromEnvOrConfig(bg.SenderHashSalt)
+			if err != nil {
+				log.Warn("failed to read sender_hash_salt, routing will fall back to default", "backend_group", bgName, "err", err)
+			} else if salt == "" {
+				log.Warn("sender_hash_salt is empty, routing will fall back to default", "backend_group", bgName)
+			} else {
+				senderHashRouter = NewSenderHashRouter(salt)
+				log.Info("initialized sender_hash routing", "backend_group", bgName)
+			}
+		}
+
 		backendGroups[bgName] = &BackendGroup{
 			Name:                   bgName,
 			Backends:               backends,
 			WeightedRouting:        bg.WeightedRouting,
 			FallbackBackends:       fallbackBackends,
 			routingStrategy:        bg.RoutingStrategy,
+			senderHashRouter:       senderHashRouter,
 			multicallRPCErrorCheck: bg.MulticallRPCErrorCheck,
 			maxBlockRange:          maxBlockRange,
 		}

--- a/proxyd/sender_hash_router.go
+++ b/proxyd/sender_hash_router.go
@@ -110,8 +110,8 @@ func IsSendRawTransactionMethod(method string) bool {
 		method == "eth_sendRawTransactionSync"
 }
 
-// parseRawTx parses the raw transaction from the request parameters.
-func parseRawTx(req *RPCReq) (*types.Transaction, error) {
+// ParseRawTx parses the raw transaction from the request parameters.
+func ParseRawTx(req *RPCReq) (*types.Transaction, error) {
 	var params []string
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return nil, err

--- a/proxyd/sender_hash_router.go
+++ b/proxyd/sender_hash_router.go
@@ -9,8 +9,6 @@ import (
 	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -50,12 +48,9 @@ func (r *SenderHashRouter) OrderedBackendsForSender(senderAddress common.Address
 		return nil
 	}
 
-	// Get the health and score for each backend and sort it
-	//
-	// Note: `b.IsHealthy()` calls on the backend's probeSpec to check if the backend is healthy.
-	scored := make([]scoredBackend, len(backends))
+	scored := make([]*scoredBackend, len(backends))
 	for i, b := range backends {
-		scored[i] = scoredBackend{
+		scored[i] = &scoredBackend{
 			backend: b,
 			score:   r.computeScore(senderAddress, b.Name),
 			healthy: b.IsHealthy(),
@@ -72,9 +67,8 @@ func (r *SenderHashRouter) OrderedBackendsForSender(senderAddress common.Address
 }
 
 // sortScoredBackends sorts backends by health (healthy first) then by score (descending).
-// `slices.SortFunc` is O(n log n).
-func sortScoredBackends(scored []scoredBackend) {
-	slices.SortFunc(scored, func(a, b scoredBackend) int {
+func sortScoredBackends(scored []*scoredBackend) {
+	slices.SortFunc(scored, func(a, b *scoredBackend) int {
 		if a.healthy != b.healthy {
 			if a.healthy {
 				return -1
@@ -85,24 +79,6 @@ func sortScoredBackends(scored []scoredBackend) {
 	})
 }
 
-// ExtractSenderFromTx extracts the sender from the transaction.
-func ExtractSenderFromTx(ctx context.Context, tx *types.Transaction) (common.Address, error) {
-	var signer types.Signer
-	if tx.ChainId().Sign() == 0 {
-		signer = new(types.HomesteadSigner)
-	} else {
-		signer = types.LatestSignerForChainID(tx.ChainId())
-	}
-
-	from, err := types.Sender(signer, tx)
-	if err != nil {
-		log.Debug("failed to extract sender from transaction", "err", err, "req_id", GetReqID(ctx))
-		return common.Address{}, err
-	}
-
-	return from, nil
-}
-
 // IsSendRawTransactionMethod checks if the method is a sendRawTransaction equivalent method.
 func IsSendRawTransactionMethod(method string) bool {
 	return method == "eth_sendRawTransaction" ||
@@ -110,26 +86,52 @@ func IsSendRawTransactionMethod(method string) bool {
 		method == "eth_sendRawTransactionSync"
 }
 
-// ParseRawTx parses the raw transaction from the request parameters.
-func ParseRawTx(req *RPCReq) (*types.Transaction, error) {
-	var params []string
-	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return nil, err
+// SplitBatchBySender splits a batch of RPC requests into groups based on sender address.
+// Returns a map of sender address to requests, plus requests that should use default routing.
+func (r *SenderHashRouter) SplitBatchBySender(ctx context.Context, reqs []*RPCReq) (map[common.Address][]*RPCReq, []*RPCReq) {
+	senderReqs := make(map[common.Address][]*RPCReq)
+	var defaultReqs []*RPCReq
+
+	// Find out which requests are sendRawTransaction requests and which are not.
+	for _, req := range reqs {
+		if !IsSendRawTransactionMethod(req.Method) {
+			defaultReqs = append(defaultReqs, req)
+			continue
+		}
+
+		// Parse the transaction parameters
+		var params []string
+		if err := json.Unmarshal(req.Params, &params); err != nil || len(params) == 0 {
+			log.Debug("failed to parse tx params, using default routing",
+				"req_id", GetReqID(ctx),
+				"err", err,
+			)
+			defaultReqs = append(defaultReqs, req)
+			continue
+		}
+		tx, err := decodeSignedTx(ctx, params[0])
+		if err != nil {
+			log.Debug("failed to decode tx, using default routing",
+				"req_id", GetReqID(ctx),
+				"err", err,
+			)
+			defaultReqs = append(defaultReqs, req)
+			continue
+		}
+
+		// Extract the sender address from the transaction
+		sender, err := getSender(tx)
+		if err != nil {
+			log.Debug("failed to extract sender, using default routing",
+				"req_id", GetReqID(ctx),
+				"err", err,
+			)
+			defaultReqs = append(defaultReqs, req)
+			continue
+		}
+
+		senderReqs[sender] = append(senderReqs[sender], req)
 	}
 
-	if len(params) == 0 {
-		return nil, ErrInvalidParams("missing transaction data")
-	}
-
-	var data hexutil.Bytes
-	if err := data.UnmarshalText([]byte(params[0])); err != nil {
-		return nil, err
-	}
-
-	tx := new(types.Transaction)
-	if err := tx.UnmarshalBinary(data); err != nil {
-		return nil, err
-	}
-
-	return tx, nil
+	return senderReqs, defaultReqs
 }

--- a/proxyd/sender_hash_router.go
+++ b/proxyd/sender_hash_router.go
@@ -1,10 +1,12 @@
 package proxyd
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -12,38 +14,27 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// SenderHashRouter is a router that selects a backend for a sender address based on the sender hash.
 type SenderHashRouter struct {
 	salt []byte
 }
 
+// scoredBackend is a backend with a score and a healthy flag.
+type scoredBackend struct {
+	backend *Backend
+	score   uint64
+	healthy bool
+}
+
+// NewSenderHashRouter creates a new sender hash router with the given salt.
 func NewSenderHashRouter(salt string) *SenderHashRouter {
 	return &SenderHashRouter{salt: []byte(salt)}
 }
 
-func (r *SenderHashRouter) SelectBackend(senderAddress common.Address, backends []*Backend) *Backend {
-	healthyBackends := filterHealthyBackends(backends)
-	if len(healthyBackends) == 0 {
-		return nil
-	}
-
-	if len(healthyBackends) == 1 {
-		return healthyBackends[0]
-	}
-
-	var selectedBackend *Backend
-	var maxScore uint64
-
-	for _, backend := range healthyBackends {
-		score := r.computeScore(senderAddress, backend.Name)
-		if score > maxScore {
-			maxScore = score
-			selectedBackend = backend
-		}
-	}
-
-	return selectedBackend
-}
-
+// computeScore implements Highest Random Weighted hashing by computing
+// a score from hash(senderAddress + salt + backendName).
+//
+// It returns the first 8 bytes of the hash as a uint64.
 func (r *SenderHashRouter) computeScore(senderAddress common.Address, backendName string) uint64 {
 	h := sha256.New()
 	h.Write(senderAddress.Bytes())
@@ -53,17 +44,15 @@ func (r *SenderHashRouter) computeScore(senderAddress common.Address, backendNam
 	return binary.BigEndian.Uint64(hash[:8])
 }
 
+// OrderedBackendsForSender returns the ordered backends for the given sender address.
 func (r *SenderHashRouter) OrderedBackendsForSender(senderAddress common.Address, backends []*Backend) []*Backend {
 	if len(backends) == 0 {
 		return nil
 	}
 
-	type scoredBackend struct {
-		backend *Backend
-		score   uint64
-		healthy bool
-	}
-
+	// Get the health and score for each backend and sort it
+	//
+	// Note: `b.IsHealthy()` calls on the backend's probeSpec to check if the backend is healthy.
 	scored := make([]scoredBackend, len(backends))
 	for i, b := range backends {
 		scored[i] = scoredBackend{
@@ -72,25 +61,7 @@ func (r *SenderHashRouter) OrderedBackendsForSender(senderAddress common.Address
 			healthy: b.IsHealthy(),
 		}
 	}
-
-	for i := 0; i < len(scored)-1; i++ {
-		for j := i + 1; j < len(scored); j++ {
-			swapNeeded := false
-			if scored[i].healthy && scored[j].healthy {
-				swapNeeded = scored[j].score > scored[i].score
-			} else if !scored[i].healthy && scored[j].healthy {
-				swapNeeded = true
-			} else if scored[i].healthy && !scored[j].healthy {
-				swapNeeded = false
-			} else {
-				swapNeeded = scored[j].score > scored[i].score
-			}
-
-			if swapNeeded {
-				scored[i], scored[j] = scored[j], scored[i]
-			}
-		}
-	}
+	sortScoredBackends(scored)
 
 	result := make([]*Backend, len(scored))
 	for i, sb := range scored {
@@ -100,16 +71,21 @@ func (r *SenderHashRouter) OrderedBackendsForSender(senderAddress common.Address
 	return result
 }
 
-func filterHealthyBackends(backends []*Backend) []*Backend {
-	healthy := make([]*Backend, 0, len(backends))
-	for _, b := range backends {
-		if b.IsHealthy() {
-			healthy = append(healthy, b)
+// sortScoredBackends sorts backends by health (healthy first) then by score (descending).
+// `slices.SortFunc` is O(n log n).
+func sortScoredBackends(scored []scoredBackend) {
+	slices.SortFunc(scored, func(a, b scoredBackend) int {
+		if a.healthy != b.healthy {
+			if a.healthy {
+				return -1
+			}
+			return 1
 		}
-	}
-	return healthy
+		return cmp.Compare(b.score, a.score)
+	})
 }
 
+// ExtractSenderFromTx extracts the sender from the transaction.
 func ExtractSenderFromTx(ctx context.Context, tx *types.Transaction) (common.Address, error) {
 	var signer types.Signer
 	if tx.ChainId().Sign() == 0 {
@@ -127,12 +103,14 @@ func ExtractSenderFromTx(ctx context.Context, tx *types.Transaction) (common.Add
 	return from, nil
 }
 
+// IsSendRawTransactionMethod checks if the method is a sendRawTransaction equivalent method.
 func IsSendRawTransactionMethod(method string) bool {
 	return method == "eth_sendRawTransaction" ||
 		method == "eth_sendRawTransactionConditional" ||
 		method == "eth_sendRawTransactionSync"
 }
 
+// parseRawTx parses the raw transaction from the request parameters.
 func parseRawTx(req *RPCReq) (*types.Transaction, error) {
 	var params []string
 	if err := json.Unmarshal(req.Params, &params); err != nil {

--- a/proxyd/sender_hash_router.go
+++ b/proxyd/sender_hash_router.go
@@ -1,0 +1,157 @@
+package proxyd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type SenderHashRouter struct {
+	salt []byte
+}
+
+func NewSenderHashRouter(salt string) *SenderHashRouter {
+	return &SenderHashRouter{salt: []byte(salt)}
+}
+
+func (r *SenderHashRouter) SelectBackend(senderAddress common.Address, backends []*Backend) *Backend {
+	healthyBackends := filterHealthyBackends(backends)
+	if len(healthyBackends) == 0 {
+		return nil
+	}
+
+	if len(healthyBackends) == 1 {
+		return healthyBackends[0]
+	}
+
+	var selectedBackend *Backend
+	var maxScore uint64
+
+	for _, backend := range healthyBackends {
+		score := r.computeScore(senderAddress, backend.Name)
+		if score > maxScore {
+			maxScore = score
+			selectedBackend = backend
+		}
+	}
+
+	return selectedBackend
+}
+
+func (r *SenderHashRouter) computeScore(senderAddress common.Address, backendName string) uint64 {
+	h := sha256.New()
+	h.Write(senderAddress.Bytes())
+	h.Write(r.salt)
+	h.Write([]byte(backendName))
+	hash := h.Sum(nil)
+	return binary.BigEndian.Uint64(hash[:8])
+}
+
+func (r *SenderHashRouter) OrderedBackendsForSender(senderAddress common.Address, backends []*Backend) []*Backend {
+	if len(backends) == 0 {
+		return nil
+	}
+
+	type scoredBackend struct {
+		backend *Backend
+		score   uint64
+		healthy bool
+	}
+
+	scored := make([]scoredBackend, len(backends))
+	for i, b := range backends {
+		scored[i] = scoredBackend{
+			backend: b,
+			score:   r.computeScore(senderAddress, b.Name),
+			healthy: b.IsHealthy(),
+		}
+	}
+
+	for i := 0; i < len(scored)-1; i++ {
+		for j := i + 1; j < len(scored); j++ {
+			swapNeeded := false
+			if scored[i].healthy && scored[j].healthy {
+				swapNeeded = scored[j].score > scored[i].score
+			} else if !scored[i].healthy && scored[j].healthy {
+				swapNeeded = true
+			} else if scored[i].healthy && !scored[j].healthy {
+				swapNeeded = false
+			} else {
+				swapNeeded = scored[j].score > scored[i].score
+			}
+
+			if swapNeeded {
+				scored[i], scored[j] = scored[j], scored[i]
+			}
+		}
+	}
+
+	result := make([]*Backend, len(scored))
+	for i, sb := range scored {
+		result[i] = sb.backend
+	}
+
+	return result
+}
+
+func filterHealthyBackends(backends []*Backend) []*Backend {
+	healthy := make([]*Backend, 0, len(backends))
+	for _, b := range backends {
+		if b.IsHealthy() {
+			healthy = append(healthy, b)
+		}
+	}
+	return healthy
+}
+
+func ExtractSenderFromTx(ctx context.Context, tx *types.Transaction) (common.Address, error) {
+	var signer types.Signer
+	if tx.ChainId().Sign() == 0 {
+		signer = new(types.HomesteadSigner)
+	} else {
+		signer = types.LatestSignerForChainID(tx.ChainId())
+	}
+
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		log.Debug("failed to extract sender from transaction", "err", err, "req_id", GetReqID(ctx))
+		return common.Address{}, err
+	}
+
+	return from, nil
+}
+
+func IsSendRawTransactionMethod(method string) bool {
+	return method == "eth_sendRawTransaction" ||
+		method == "eth_sendRawTransactionConditional" ||
+		method == "eth_sendRawTransactionSync"
+}
+
+func parseRawTx(req *RPCReq) (*types.Transaction, error) {
+	var params []string
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, err
+	}
+
+	if len(params) == 0 {
+		return nil, ErrInvalidParams("missing transaction data")
+	}
+
+	var data hexutil.Bytes
+	if err := data.UnmarshalText([]byte(params[0])); err != nil {
+		return nil, err
+	}
+
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}

--- a/proxyd/sender_hash_router_test.go
+++ b/proxyd/sender_hash_router_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 )
@@ -22,7 +20,7 @@ func createMockBackend(name string, healthy bool) *Backend {
 // TestSortScoredBackends tests the sortScoredBackends function.
 func TestSortScoredBackends(t *testing.T) {
 	t.Run("healthy backends sorted before unhealthy", func(t *testing.T) {
-		scored := []scoredBackend{
+		scored := []*scoredBackend{
 			{backend: &Backend{Name: "unhealthy-1"}, score: 100, healthy: false},
 			{backend: &Backend{Name: "healthy-1"}, score: 50, healthy: true},
 			{backend: &Backend{Name: "unhealthy-2"}, score: 200, healthy: false},
@@ -38,7 +36,7 @@ func TestSortScoredBackends(t *testing.T) {
 	})
 
 	t.Run("within same health status sorted by score descending", func(t *testing.T) {
-		scored := []scoredBackend{
+		scored := []*scoredBackend{
 			{backend: &Backend{Name: "low"}, score: 10, healthy: true},
 			{backend: &Backend{Name: "high"}, score: 100, healthy: true},
 			{backend: &Backend{Name: "mid"}, score: 50, healthy: true},
@@ -52,7 +50,7 @@ func TestSortScoredBackends(t *testing.T) {
 	})
 
 	t.Run("unhealthy backends also sorted by score descending", func(t *testing.T) {
-		scored := []scoredBackend{
+		scored := []*scoredBackend{
 			{backend: &Backend{Name: "low"}, score: 10, healthy: false},
 			{backend: &Backend{Name: "high"}, score: 100, healthy: false},
 			{backend: &Backend{Name: "mid"}, score: 50, healthy: false},
@@ -66,13 +64,13 @@ func TestSortScoredBackends(t *testing.T) {
 	})
 
 	t.Run("empty slice", func(t *testing.T) {
-		scored := []scoredBackend{}
+		scored := []*scoredBackend{}
 		sortScoredBackends(scored)
 		require.Empty(t, scored)
 	})
 
 	t.Run("single element", func(t *testing.T) {
-		scored := []scoredBackend{
+		scored := []*scoredBackend{
 			{backend: &Backend{Name: "only"}, score: 42, healthy: true},
 		}
 		sortScoredBackends(scored)
@@ -81,7 +79,7 @@ func TestSortScoredBackends(t *testing.T) {
 	})
 
 	t.Run("mixed health and scores", func(t *testing.T) {
-		scored := []scoredBackend{
+		scored := []*scoredBackend{
 			{backend: &Backend{Name: "u-low"}, score: 5, healthy: false},
 			{backend: &Backend{Name: "h-high"}, score: 100, healthy: true},
 			{backend: &Backend{Name: "u-high"}, score: 200, healthy: false},
@@ -322,100 +320,6 @@ func TestIsSendRawTransactionMethod(t *testing.T) {
 	}
 }
 
-// TestExtractSenderFromTx verifies that the sender address is correctly extracted
-// from a signed transaction.
-func TestExtractSenderFromTx(t *testing.T) {
-	tests := []struct {
-		name           string
-		txHex          string
-		expectedSender string
-	}{
-		{
-			name: "EIP-1559 tx on chain 420",
-			txHex: "0x02f8b28201a406849502f931849502f931830147f9948f3ddd0fbf3e78ca1d6c" +
-				"d17379ed88e261249b5280b84447e7ef2400000000000000000000000089c8b1" +
-				"b2774201bac50f627403eac1b732459cf7000000000000000000000000000000" +
-				"0000000000000000056bc75e2d63100000c080a0473c95566026c312c9664cd6" +
-				"1145d2f3e759d49209fe96011ac012884ec5b017a0763b58f6fa6096e6ba28ee" +
-				"08bfac58f58fb3b8bcef5af98578bdeaddf40bde42",
-			expectedSender: "0x155c651ABd923B19f7b5440F23d3ba1a57784876",
-		},
-		{
-			name: "simple transfer on chain 420",
-			txHex: "0x02f8758201a48217fd84773594008504a817c80082520894be53e587975603" +
-				"a13d0923d0aa6d37c5233dd750865af3107a400080c080a04aefbd5819c35729" +
-				"138fe26b6ae1783ebf08d249b356c2f920345db97877f3f7a008d5ae92560a3c" +
-				"65f723439887205713af7ce7d7f6b24fba198f2afa03435867",
-			expectedSender: "0xbe53E587975603A13D0923D0AA6d37C5233DD750",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			data, err := hexutil.Decode(tt.txHex)
-			require.NoError(t, err)
-
-			tx := new(types.Transaction)
-			err = tx.UnmarshalBinary(data)
-			require.NoError(t, err)
-
-			sender, err := ExtractSenderFromTx(context.Background(), tx)
-			require.NoError(t, err)
-			require.Equal(t, tt.expectedSender, sender.Hex())
-		})
-	}
-}
-
-// TestParseRawTx verifies that raw transaction hex is correctly parsed.
-func TestParseRawTx(t *testing.T) {
-	t.Run("invalid params", func(t *testing.T) {
-		req := &RPCReq{
-			Method: "eth_sendRawTransaction",
-			Params: []byte(`"not an array"`),
-		}
-
-		_, err := ParseRawTx(req)
-		require.Error(t, err)
-	})
-
-	t.Run("empty params", func(t *testing.T) {
-		req := &RPCReq{
-			Method: "eth_sendRawTransaction",
-			Params: []byte(`[]`),
-		}
-
-		_, err := ParseRawTx(req)
-		require.Error(t, err)
-	})
-
-	t.Run("invalid hex", func(t *testing.T) {
-		req := &RPCReq{
-			Method: "eth_sendRawTransaction",
-			Params: []byte(`["not-valid-hex"]`),
-		}
-
-		_, err := ParseRawTx(req)
-		require.Error(t, err)
-	})
-
-	t.Run("valid hex", func(t *testing.T) {
-		validTxHex := "0x02f8b28201a406849502f931849502f931830147f9948f3ddd0fbf3e78ca1d6c" +
-			"d17379ed88e261249b5280b84447e7ef2400000000000000000000000089c8b1" +
-			"b2774201bac50f627403eac1b732459cf7000000000000000000000000000000" +
-			"0000000000000000056bc75e2d63100000c080a0473c95566026c312c9664cd6" +
-			"1145d2f3e759d49209fe96011ac012884ec5b017a0763b58f6fa6096e6ba28ee" +
-			"08bfac58f58fb3b8bcef5af98578bdeaddf40bde42"
-		req := &RPCReq{
-			Method: "eth_sendRawTransaction",
-			Params: []byte(`["` + validTxHex + `"]`),
-		}
-
-		tx, err := ParseRawTx(req)
-		require.NoError(t, err)
-		require.NotNil(t, tx)
-	})
-}
-
 // TestSenderHashRouter_DifferentSendersDistribute verifies that different senders
 // are distributed across multiple backends (not all routed to the same one).
 func TestSenderHashRouter_DifferentSendersDistribute(t *testing.T) {
@@ -443,4 +347,88 @@ func TestSenderHashRouter_DifferentSendersDistribute(t *testing.T) {
 	}
 
 	require.GreaterOrEqual(t, len(selections), 2)
+}
+
+// TestSplitBatchBySender verifies that batch requests are correctly split by sender.
+func TestSplitBatchBySender(t *testing.T) {
+	router := NewSenderHashRouter("batch-split-salt")
+
+	txHex1 := "0x02f8b28201a406849502f931849502f931830147f9948f3ddd0fbf3e78ca1d6c" +
+		"d17379ed88e261249b5280b84447e7ef2400000000000000000000000089c8b1" +
+		"b2774201bac50f627403eac1b732459cf7000000000000000000000000000000" +
+		"0000000000000000056bc75e2d63100000c080a0473c95566026c312c9664cd6" +
+		"1145d2f3e759d49209fe96011ac012884ec5b017a0763b58f6fa6096e6ba28ee" +
+		"08bfac58f58fb3b8bcef5af98578bdeaddf40bde42"
+
+	txHex2 := "0x02f8758201a48217fd84773594008504a817c80082520894be53e587975603" +
+		"a13d0923d0aa6d37c5233dd750865af3107a400080c080a04aefbd5819c35729" +
+		"138fe26b6ae1783ebf08d249b356c2f920345db97877f3f7a008d5ae92560a3c" +
+		"65f723439887205713af7ce7d7f6b24fba198f2afa03435867"
+
+	t.Run("splits sendRawTx by sender", func(t *testing.T) {
+		reqs := []*RPCReq{
+			{Method: "eth_sendRawTransaction", Params: []byte(`["` + txHex1 + `"]`), ID: []byte(`1`)},
+			{Method: "eth_sendRawTransaction", Params: []byte(`["` + txHex2 + `"]`), ID: []byte(`2`)},
+		}
+
+		senderReqs, defaultReqs := router.SplitBatchBySender(context.Background(), reqs)
+
+		require.Empty(t, defaultReqs, "no requests should fall back to default routing")
+		require.Len(t, senderReqs, 2, "two different senders should map to entries")
+
+		totalReqs := 0
+		for _, reqs := range senderReqs {
+			totalReqs += len(reqs)
+		}
+		require.Equal(t, 2, totalReqs)
+	})
+
+	t.Run("non-sendRawTx goes to default", func(t *testing.T) {
+		reqs := []*RPCReq{
+			{Method: "eth_sendRawTransaction", Params: []byte(`["` + txHex1 + `"]`), ID: []byte(`1`)},
+			{Method: "eth_call", Params: []byte(`[{}]`), ID: []byte(`2`)},
+			{Method: "eth_getBalance", Params: []byte(`["0x123", "latest"]`), ID: []byte(`3`)},
+		}
+
+		senderReqs, defaultReqs := router.SplitBatchBySender(context.Background(), reqs)
+
+		require.Len(t, defaultReqs, 2, "eth_call and eth_getBalance should use default routing")
+		require.Len(t, senderReqs, 1, "one sendRawTx should be routed by sender")
+	})
+
+	t.Run("same sender txs grouped together", func(t *testing.T) {
+		reqs := []*RPCReq{
+			{Method: "eth_sendRawTransaction", Params: []byte(`["` + txHex1 + `"]`), ID: []byte(`1`)},
+			{Method: "eth_sendRawTransaction", Params: []byte(`["` + txHex1 + `"]`), ID: []byte(`2`)},
+			{Method: "eth_sendRawTransaction", Params: []byte(`["` + txHex1 + `"]`), ID: []byte(`3`)},
+		}
+
+		senderReqs, defaultReqs := router.SplitBatchBySender(context.Background(), reqs)
+
+		require.Empty(t, defaultReqs)
+		require.Len(t, senderReqs, 1, "all txs from same sender should be grouped")
+
+		for _, reqs := range senderReqs {
+			require.Len(t, reqs, 3, "all 3 requests should be grouped")
+		}
+	})
+
+	t.Run("invalid tx falls back to default", func(t *testing.T) {
+		reqs := []*RPCReq{
+			{Method: "eth_sendRawTransaction", Params: []byte(`["0xinvalid"]`), ID: []byte(`1`)},
+			{Method: "eth_sendRawTransaction", Params: []byte(`["` + txHex1 + `"]`), ID: []byte(`2`)},
+		}
+
+		senderReqs, defaultReqs := router.SplitBatchBySender(context.Background(), reqs)
+
+		require.Len(t, defaultReqs, 1, "invalid tx should fall back to default")
+		require.Len(t, senderReqs, 1, "valid tx should be routed by sender")
+	})
+
+	t.Run("empty batch", func(t *testing.T) {
+		senderReqs, defaultReqs := router.SplitBatchBySender(context.Background(), []*RPCReq{})
+
+		require.Empty(t, senderReqs)
+		require.Empty(t, defaultReqs)
+	})
 }

--- a/proxyd/sender_hash_router_test.go
+++ b/proxyd/sender_hash_router_test.go
@@ -1,0 +1,411 @@
+package proxyd
+
+import (
+	"math"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+)
+
+func createMockBackend(name string, healthy bool) *Backend {
+	b := NewBackend(name, "http://localhost:8545", "", semaphore.NewWeighted(10))
+	b.probeSpec = &ProbeSpec{}
+	b.healthyProbe.Store(healthy)
+	return b
+}
+
+func TestSenderHashRouter_DeterministicRouting(t *testing.T) {
+	router := NewSenderHashRouter("test-salt")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+		createMockBackend("backend-3", true),
+	}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+
+	selected1 := router.SelectBackend(sender, backends)
+	selected2 := router.SelectBackend(sender, backends)
+	selected3 := router.SelectBackend(sender, backends)
+
+	require.NotNil(t, selected1)
+	require.Equal(t, selected1.Name, selected2.Name)
+	require.Equal(t, selected2.Name, selected3.Name)
+}
+
+func TestSenderHashRouter_SaltSensitivity(t *testing.T) {
+	router1 := NewSenderHashRouter("salt-one")
+	router2 := NewSenderHashRouter("salt-two")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+		createMockBackend("backend-3", true),
+		createMockBackend("backend-4", true),
+		createMockBackend("backend-5", true),
+	}
+
+	differentSelections := 0
+	for i := 0; i < 100; i++ {
+		sender := common.HexToAddress("0x" + string(rune('A'+i%26)) + "42d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+		selected1 := router1.SelectBackend(sender, backends)
+		selected2 := router2.SelectBackend(sender, backends)
+
+		if selected1.Name != selected2.Name {
+			differentSelections++
+		}
+	}
+
+	require.Greater(t, differentSelections, 0)
+}
+
+func TestSenderHashRouter_DistributionQuality(t *testing.T) {
+	router := NewSenderHashRouter("distribution-test-salt")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+		createMockBackend("backend-3", true),
+	}
+
+	counts := make(map[string]int)
+	numSamples := 3000
+
+	for i := 0; i < numSamples; i++ {
+		sender := common.BigToAddress(common.Big1.Add(common.Big1, common.Big1.SetInt64(int64(i*12345))))
+		selected := router.SelectBackend(sender, backends)
+		counts[selected.Name]++
+	}
+
+	expectedPerBackend := float64(numSamples) / float64(len(backends))
+	tolerance := expectedPerBackend * 0.25
+
+	for name, count := range counts {
+		deviation := math.Abs(float64(count) - expectedPerBackend)
+		require.LessOrEqual(t, deviation, tolerance,
+			"Backend %s has count %d, expected ~%.0f (deviation %.0f > tolerance %.0f)",
+			name, count, expectedPerBackend, deviation, tolerance)
+	}
+}
+
+func TestSenderHashRouter_HealthAwareRouting(t *testing.T) {
+	router := NewSenderHashRouter("health-test-salt")
+
+	healthyBackend := createMockBackend("healthy-backend", true)
+	unhealthyBackend1 := createMockBackend("unhealthy-1", false)
+	unhealthyBackend2 := createMockBackend("unhealthy-2", false)
+
+	backends := []*Backend{unhealthyBackend1, healthyBackend, unhealthyBackend2}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+	selected := router.SelectBackend(sender, backends)
+
+	require.NotNil(t, selected)
+	require.Equal(t, "healthy-backend", selected.Name)
+}
+
+func TestSenderHashRouter_AllUnhealthy(t *testing.T) {
+	router := NewSenderHashRouter("all-unhealthy-salt")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", false),
+		createMockBackend("backend-2", false),
+		createMockBackend("backend-3", false),
+	}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+	selected := router.SelectBackend(sender, backends)
+
+	require.Nil(t, selected)
+}
+
+func TestSenderHashRouter_EmptyBackends(t *testing.T) {
+	router := NewSenderHashRouter("empty-test-salt")
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+	selected := router.SelectBackend(sender, []*Backend{})
+
+	require.Nil(t, selected)
+}
+
+func TestSenderHashRouter_SingleBackend(t *testing.T) {
+	router := NewSenderHashRouter("single-backend-salt")
+
+	backend := createMockBackend("only-backend", true)
+	backends := []*Backend{backend}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+	selected := router.SelectBackend(sender, backends)
+
+	require.NotNil(t, selected)
+	require.Equal(t, "only-backend", selected.Name)
+}
+
+func TestSenderHashRouter_OrderedBackendsForSender(t *testing.T) {
+	router := NewSenderHashRouter("ordered-test-salt")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+		createMockBackend("backend-3", true),
+	}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+
+	ordered1 := router.OrderedBackendsForSender(sender, backends)
+	ordered2 := router.OrderedBackendsForSender(sender, backends)
+
+	require.Len(t, ordered1, 3)
+	require.Len(t, ordered2, 3)
+
+	for i := range ordered1 {
+		require.Equal(t, ordered1[i].Name, ordered2[i].Name)
+	}
+}
+
+func TestSenderHashRouter_OrderedBackendsHealthyFirst(t *testing.T) {
+	router := NewSenderHashRouter("healthy-first-salt")
+
+	backends := []*Backend{
+		createMockBackend("unhealthy-1", false),
+		createMockBackend("healthy-1", true),
+		createMockBackend("unhealthy-2", false),
+		createMockBackend("healthy-2", true),
+	}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+
+	ordered := router.OrderedBackendsForSender(sender, backends)
+
+	require.Len(t, ordered, 4)
+
+	require.True(t, ordered[0].IsHealthy())
+	require.True(t, ordered[1].IsHealthy())
+	require.False(t, ordered[2].IsHealthy())
+	require.False(t, ordered[3].IsHealthy())
+}
+
+func TestSenderHashRouter_FailoverBehavior(t *testing.T) {
+	router := NewSenderHashRouter("failover-salt")
+
+	backend1 := createMockBackend("backend-1", true)
+	backend2 := createMockBackend("backend-2", true)
+	backend3 := createMockBackend("backend-3", true)
+
+	backends := []*Backend{backend1, backend2, backend3}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+
+	orderedBefore := router.OrderedBackendsForSender(sender, backends)
+	primaryName := orderedBefore[0].Name
+	secondaryName := orderedBefore[1].Name
+
+	for _, b := range backends {
+		if b.Name == primaryName {
+			b.healthyProbe.Store(false)
+		}
+	}
+
+	orderedAfter := router.OrderedBackendsForSender(sender, backends)
+
+	require.Equal(t, secondaryName, orderedAfter[0].Name)
+}
+
+func TestSenderHashRouter_ConcurrentAccess(t *testing.T) {
+	router := NewSenderHashRouter("concurrent-salt")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+		createMockBackend("backend-3", true),
+	}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+
+	var successCount atomic.Int32
+	numGoroutines := 100
+
+	done := make(chan bool, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			selected := router.SelectBackend(sender, backends)
+			if selected != nil {
+				successCount.Add(1)
+			}
+			done <- true
+		}()
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		<-done
+	}
+
+	require.Equal(t, int32(numGoroutines), successCount.Load())
+}
+
+func TestIsSendRawTransactionMethod(t *testing.T) {
+	tests := []struct {
+		method   string
+		expected bool
+	}{
+		{"eth_sendRawTransaction", true},
+		{"eth_sendRawTransactionConditional", true},
+		{"eth_sendRawTransactionSync", true},
+		{"eth_call", false},
+		{"eth_getBalance", false},
+		{"eth_getTransactionReceipt", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			result := IsSendRawTransactionMethod(tt.method)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFilterHealthyBackends(t *testing.T) {
+	backends := []*Backend{
+		createMockBackend("healthy-1", true),
+		createMockBackend("unhealthy-1", false),
+		createMockBackend("healthy-2", true),
+		createMockBackend("unhealthy-2", false),
+	}
+
+	healthy := filterHealthyBackends(backends)
+
+	require.Len(t, healthy, 2)
+	for _, b := range healthy {
+		require.True(t, b.IsHealthy())
+	}
+}
+
+func TestExtractSenderFromTx(t *testing.T) {
+	t.Skip("Skipping sender extraction test - requires signed transaction fixtures")
+}
+
+func TestParseRawTx(t *testing.T) {
+	t.Run("invalid params", func(t *testing.T) {
+		req := &RPCReq{
+			Method: "eth_sendRawTransaction",
+			Params: []byte(`"not an array"`),
+		}
+
+		_, err := parseRawTx(req)
+		require.Error(t, err)
+	})
+
+	t.Run("empty params", func(t *testing.T) {
+		req := &RPCReq{
+			Method: "eth_sendRawTransaction",
+			Params: []byte(`[]`),
+		}
+
+		_, err := parseRawTx(req)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid hex", func(t *testing.T) {
+		req := &RPCReq{
+			Method: "eth_sendRawTransaction",
+			Params: []byte(`["not-valid-hex"]`),
+		}
+
+		_, err := parseRawTx(req)
+		require.Error(t, err)
+	})
+}
+
+func TestNewSenderHashRouter(t *testing.T) {
+	router := NewSenderHashRouter("my-secret-salt")
+	require.NotNil(t, router)
+	require.Equal(t, []byte("my-secret-salt"), router.salt)
+}
+
+func TestSenderHashRouter_EmptySalt(t *testing.T) {
+	router := NewSenderHashRouter("")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+	}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+	selected := router.SelectBackend(sender, backends)
+
+	require.NotNil(t, selected)
+
+	selected2 := router.SelectBackend(sender, backends)
+	require.Equal(t, selected.Name, selected2.Name)
+}
+
+func TestSenderHashRouter_DifferentSendersDistribute(t *testing.T) {
+	router := NewSenderHashRouter("distribution-salt")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+		createMockBackend("backend-3", true),
+	}
+
+	senders := []common.Address{
+		common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		common.HexToAddress("0x3333333333333333333333333333333333333333"),
+		common.HexToAddress("0x4444444444444444444444444444444444444444"),
+		common.HexToAddress("0x5555555555555555555555555555555555555555"),
+		common.HexToAddress("0x6666666666666666666666666666666666666666"),
+	}
+
+	selections := make(map[string]bool)
+	for _, sender := range senders {
+		selected := router.SelectBackend(sender, backends)
+		selections[selected.Name] = true
+	}
+
+	require.GreaterOrEqual(t, len(selections), 2)
+}
+
+func BenchmarkSenderHashRouter_SelectBackend(b *testing.B) {
+	router := NewSenderHashRouter("benchmark-salt")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+		createMockBackend("backend-3", true),
+		createMockBackend("backend-4", true),
+		createMockBackend("backend-5", true),
+	}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		router.SelectBackend(sender, backends)
+	}
+}
+
+func BenchmarkSenderHashRouter_OrderedBackendsForSender(b *testing.B) {
+	router := NewSenderHashRouter("benchmark-salt")
+
+	backends := []*Backend{
+		createMockBackend("backend-1", true),
+		createMockBackend("backend-2", true),
+		createMockBackend("backend-3", true),
+		createMockBackend("backend-4", true),
+		createMockBackend("backend-5", true),
+	}
+
+	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		router.OrderedBackendsForSender(sender, backends)
+	}
+}

--- a/proxyd/sender_hash_router_test.go
+++ b/proxyd/sender_hash_router_test.go
@@ -1,11 +1,13 @@
 package proxyd
 
 import (
-	"math"
+	"context"
 	"sync/atomic"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 )
@@ -17,6 +19,86 @@ func createMockBackend(name string, healthy bool) *Backend {
 	return b
 }
 
+// TestSortScoredBackends tests the sortScoredBackends function.
+func TestSortScoredBackends(t *testing.T) {
+	t.Run("healthy backends sorted before unhealthy", func(t *testing.T) {
+		scored := []scoredBackend{
+			{backend: &Backend{Name: "unhealthy-1"}, score: 100, healthy: false},
+			{backend: &Backend{Name: "healthy-1"}, score: 50, healthy: true},
+			{backend: &Backend{Name: "unhealthy-2"}, score: 200, healthy: false},
+			{backend: &Backend{Name: "healthy-2"}, score: 25, healthy: true},
+		}
+
+		sortScoredBackends(scored)
+
+		require.True(t, scored[0].healthy)
+		require.True(t, scored[1].healthy)
+		require.False(t, scored[2].healthy)
+		require.False(t, scored[3].healthy)
+	})
+
+	t.Run("within same health status sorted by score descending", func(t *testing.T) {
+		scored := []scoredBackend{
+			{backend: &Backend{Name: "low"}, score: 10, healthy: true},
+			{backend: &Backend{Name: "high"}, score: 100, healthy: true},
+			{backend: &Backend{Name: "mid"}, score: 50, healthy: true},
+		}
+
+		sortScoredBackends(scored)
+
+		require.Equal(t, uint64(100), scored[0].score)
+		require.Equal(t, uint64(50), scored[1].score)
+		require.Equal(t, uint64(10), scored[2].score)
+	})
+
+	t.Run("unhealthy backends also sorted by score descending", func(t *testing.T) {
+		scored := []scoredBackend{
+			{backend: &Backend{Name: "low"}, score: 10, healthy: false},
+			{backend: &Backend{Name: "high"}, score: 100, healthy: false},
+			{backend: &Backend{Name: "mid"}, score: 50, healthy: false},
+		}
+
+		sortScoredBackends(scored)
+
+		require.Equal(t, uint64(100), scored[0].score)
+		require.Equal(t, uint64(50), scored[1].score)
+		require.Equal(t, uint64(10), scored[2].score)
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		scored := []scoredBackend{}
+		sortScoredBackends(scored)
+		require.Empty(t, scored)
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		scored := []scoredBackend{
+			{backend: &Backend{Name: "only"}, score: 42, healthy: true},
+		}
+		sortScoredBackends(scored)
+		require.Len(t, scored, 1)
+		require.Equal(t, "only", scored[0].backend.Name)
+	})
+
+	t.Run("mixed health and scores", func(t *testing.T) {
+		scored := []scoredBackend{
+			{backend: &Backend{Name: "u-low"}, score: 5, healthy: false},
+			{backend: &Backend{Name: "h-high"}, score: 100, healthy: true},
+			{backend: &Backend{Name: "u-high"}, score: 200, healthy: false},
+			{backend: &Backend{Name: "h-low"}, score: 10, healthy: true},
+		}
+
+		sortScoredBackends(scored)
+
+		require.Equal(t, "h-high", scored[0].backend.Name)
+		require.Equal(t, "h-low", scored[1].backend.Name)
+		require.Equal(t, "u-high", scored[2].backend.Name)
+		require.Equal(t, "u-low", scored[3].backend.Name)
+	})
+}
+
+// TestSenderHashRouter_DeterministicRouting verifies that the same sender always gets
+// the same backend ordering when using the same salt.
 func TestSenderHashRouter_DeterministicRouting(t *testing.T) {
 	router := NewSenderHashRouter("test-salt")
 
@@ -28,15 +110,17 @@ func TestSenderHashRouter_DeterministicRouting(t *testing.T) {
 
 	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
 
-	selected1 := router.SelectBackend(sender, backends)
-	selected2 := router.SelectBackend(sender, backends)
-	selected3 := router.SelectBackend(sender, backends)
+	ordered1 := router.OrderedBackendsForSender(sender, backends)
+	ordered2 := router.OrderedBackendsForSender(sender, backends)
+	ordered3 := router.OrderedBackendsForSender(sender, backends)
 
-	require.NotNil(t, selected1)
-	require.Equal(t, selected1.Name, selected2.Name)
-	require.Equal(t, selected2.Name, selected3.Name)
+	require.NotEmpty(t, ordered1)
+	require.Equal(t, ordered1[0].Name, ordered2[0].Name)
+	require.Equal(t, ordered2[0].Name, ordered3[0].Name)
 }
 
+// TestSenderHashRouter_SaltSensitivity verifies that different salts produce
+// different backend orderings for the same sender.
 func TestSenderHashRouter_SaltSensitivity(t *testing.T) {
 	router1 := NewSenderHashRouter("salt-one")
 	router2 := NewSenderHashRouter("salt-two")
@@ -52,10 +136,10 @@ func TestSenderHashRouter_SaltSensitivity(t *testing.T) {
 	differentSelections := 0
 	for i := 0; i < 100; i++ {
 		sender := common.HexToAddress("0x" + string(rune('A'+i%26)) + "42d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-		selected1 := router1.SelectBackend(sender, backends)
-		selected2 := router2.SelectBackend(sender, backends)
+		ordered1 := router1.OrderedBackendsForSender(sender, backends)
+		ordered2 := router2.OrderedBackendsForSender(sender, backends)
 
-		if selected1.Name != selected2.Name {
+		if ordered1[0].Name != ordered2[0].Name {
 			differentSelections++
 		}
 	}
@@ -63,35 +147,8 @@ func TestSenderHashRouter_SaltSensitivity(t *testing.T) {
 	require.Greater(t, differentSelections, 0)
 }
 
-func TestSenderHashRouter_DistributionQuality(t *testing.T) {
-	router := NewSenderHashRouter("distribution-test-salt")
-
-	backends := []*Backend{
-		createMockBackend("backend-1", true),
-		createMockBackend("backend-2", true),
-		createMockBackend("backend-3", true),
-	}
-
-	counts := make(map[string]int)
-	numSamples := 3000
-
-	for i := 0; i < numSamples; i++ {
-		sender := common.BigToAddress(common.Big1.Add(common.Big1, common.Big1.SetInt64(int64(i*12345))))
-		selected := router.SelectBackend(sender, backends)
-		counts[selected.Name]++
-	}
-
-	expectedPerBackend := float64(numSamples) / float64(len(backends))
-	tolerance := expectedPerBackend * 0.25
-
-	for name, count := range counts {
-		deviation := math.Abs(float64(count) - expectedPerBackend)
-		require.LessOrEqual(t, deviation, tolerance,
-			"Backend %s has count %d, expected ~%.0f (deviation %.0f > tolerance %.0f)",
-			name, count, expectedPerBackend, deviation, tolerance)
-	}
-}
-
+// TestSenderHashRouter_HealthAwareRouting verifies that healthy backends are
+// sorted before unhealthy backends.
 func TestSenderHashRouter_HealthAwareRouting(t *testing.T) {
 	router := NewSenderHashRouter("health-test-salt")
 
@@ -102,12 +159,14 @@ func TestSenderHashRouter_HealthAwareRouting(t *testing.T) {
 	backends := []*Backend{unhealthyBackend1, healthyBackend, unhealthyBackend2}
 
 	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-	selected := router.SelectBackend(sender, backends)
+	ordered := router.OrderedBackendsForSender(sender, backends)
 
-	require.NotNil(t, selected)
-	require.Equal(t, "healthy-backend", selected.Name)
+	require.Len(t, ordered, 3)
+	require.Equal(t, "healthy-backend", ordered[0].Name)
 }
 
+// TestSenderHashRouter_AllUnhealthy verifies that when all backends are unhealthy,
+// they are still returned (sorted by score) as fallback options.
 func TestSenderHashRouter_AllUnhealthy(t *testing.T) {
 	router := NewSenderHashRouter("all-unhealthy-salt")
 
@@ -118,20 +177,27 @@ func TestSenderHashRouter_AllUnhealthy(t *testing.T) {
 	}
 
 	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-	selected := router.SelectBackend(sender, backends)
+	ordered := router.OrderedBackendsForSender(sender, backends)
 
-	require.Nil(t, selected)
+	require.Len(t, ordered, 3)
+	for _, b := range ordered {
+		require.False(t, b.IsHealthy())
+	}
 }
 
+// TestSenderHashRouter_EmptyBackends verifies that nil is returned when there
+// are no backends available.
 func TestSenderHashRouter_EmptyBackends(t *testing.T) {
 	router := NewSenderHashRouter("empty-test-salt")
 
 	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-	selected := router.SelectBackend(sender, []*Backend{})
+	ordered := router.OrderedBackendsForSender(sender, []*Backend{})
 
-	require.Nil(t, selected)
+	require.Nil(t, ordered)
 }
 
+// TestSenderHashRouter_SingleBackend verifies that a single backend is returned
+// as the only element in the ordered list.
 func TestSenderHashRouter_SingleBackend(t *testing.T) {
 	router := NewSenderHashRouter("single-backend-salt")
 
@@ -139,34 +205,14 @@ func TestSenderHashRouter_SingleBackend(t *testing.T) {
 	backends := []*Backend{backend}
 
 	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-	selected := router.SelectBackend(sender, backends)
+	ordered := router.OrderedBackendsForSender(sender, backends)
 
-	require.NotNil(t, selected)
-	require.Equal(t, "only-backend", selected.Name)
+	require.Len(t, ordered, 1)
+	require.Equal(t, "only-backend", ordered[0].Name)
 }
 
-func TestSenderHashRouter_OrderedBackendsForSender(t *testing.T) {
-	router := NewSenderHashRouter("ordered-test-salt")
-
-	backends := []*Backend{
-		createMockBackend("backend-1", true),
-		createMockBackend("backend-2", true),
-		createMockBackend("backend-3", true),
-	}
-
-	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-
-	ordered1 := router.OrderedBackendsForSender(sender, backends)
-	ordered2 := router.OrderedBackendsForSender(sender, backends)
-
-	require.Len(t, ordered1, 3)
-	require.Len(t, ordered2, 3)
-
-	for i := range ordered1 {
-		require.Equal(t, ordered1[i].Name, ordered2[i].Name)
-	}
-}
-
+// TestSenderHashRouter_OrderedBackendsHealthyFirst verifies that healthy backends
+// appear before unhealthy backends in the ordered list.
 func TestSenderHashRouter_OrderedBackendsHealthyFirst(t *testing.T) {
 	router := NewSenderHashRouter("healthy-first-salt")
 
@@ -189,6 +235,8 @@ func TestSenderHashRouter_OrderedBackendsHealthyFirst(t *testing.T) {
 	require.False(t, ordered[3].IsHealthy())
 }
 
+// TestSenderHashRouter_FailoverBehavior verifies that when the primary backend
+// becomes unhealthy, the secondary backend moves to the front of the list.
 func TestSenderHashRouter_FailoverBehavior(t *testing.T) {
 	router := NewSenderHashRouter("failover-salt")
 
@@ -211,10 +259,12 @@ func TestSenderHashRouter_FailoverBehavior(t *testing.T) {
 	}
 
 	orderedAfter := router.OrderedBackendsForSender(sender, backends)
-
 	require.Equal(t, secondaryName, orderedAfter[0].Name)
+	require.Equal(t, primaryName, orderedAfter[len(orderedAfter)-1].Name)
 }
 
+// TestSenderHashRouter_ConcurrentAccess verifies that the router is safe for
+// concurrent access from multiple goroutines.
 func TestSenderHashRouter_ConcurrentAccess(t *testing.T) {
 	router := NewSenderHashRouter("concurrent-salt")
 
@@ -233,8 +283,8 @@ func TestSenderHashRouter_ConcurrentAccess(t *testing.T) {
 
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
-			selected := router.SelectBackend(sender, backends)
-			if selected != nil {
+			ordered := router.OrderedBackendsForSender(sender, backends)
+			if len(ordered) > 0 {
 				successCount.Add(1)
 			}
 			done <- true
@@ -248,6 +298,8 @@ func TestSenderHashRouter_ConcurrentAccess(t *testing.T) {
 	require.Equal(t, int32(numGoroutines), successCount.Load())
 }
 
+// TestIsSendRawTransactionMethod verifies that sendRawTransaction method variants
+// are correctly identified.
 func TestIsSendRawTransactionMethod(t *testing.T) {
 	tests := []struct {
 		method   string
@@ -270,26 +322,51 @@ func TestIsSendRawTransactionMethod(t *testing.T) {
 	}
 }
 
-func TestFilterHealthyBackends(t *testing.T) {
-	backends := []*Backend{
-		createMockBackend("healthy-1", true),
-		createMockBackend("unhealthy-1", false),
-		createMockBackend("healthy-2", true),
-		createMockBackend("unhealthy-2", false),
-	}
-
-	healthy := filterHealthyBackends(backends)
-
-	require.Len(t, healthy, 2)
-	for _, b := range healthy {
-		require.True(t, b.IsHealthy())
-	}
-}
-
+// TestExtractSenderFromTx verifies that the sender address is correctly extracted
+// from a signed transaction.
 func TestExtractSenderFromTx(t *testing.T) {
-	t.Skip("Skipping sender extraction test - requires signed transaction fixtures")
+	tests := []struct {
+		name           string
+		txHex          string
+		expectedSender string
+	}{
+		{
+			name: "EIP-1559 tx on chain 420",
+			txHex: "0x02f8b28201a406849502f931849502f931830147f9948f3ddd0fbf3e78ca1d6c" +
+				"d17379ed88e261249b5280b84447e7ef2400000000000000000000000089c8b1" +
+				"b2774201bac50f627403eac1b732459cf7000000000000000000000000000000" +
+				"0000000000000000056bc75e2d63100000c080a0473c95566026c312c9664cd6" +
+				"1145d2f3e759d49209fe96011ac012884ec5b017a0763b58f6fa6096e6ba28ee" +
+				"08bfac58f58fb3b8bcef5af98578bdeaddf40bde42",
+			expectedSender: "0x155c651ABd923B19f7b5440F23d3ba1a57784876",
+		},
+		{
+			name: "simple transfer on chain 420",
+			txHex: "0x02f8758201a48217fd84773594008504a817c80082520894be53e587975603" +
+				"a13d0923d0aa6d37c5233dd750865af3107a400080c080a04aefbd5819c35729" +
+				"138fe26b6ae1783ebf08d249b356c2f920345db97877f3f7a008d5ae92560a3c" +
+				"65f723439887205713af7ce7d7f6b24fba198f2afa03435867",
+			expectedSender: "0xbe53E587975603A13D0923D0AA6d37C5233DD750",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := hexutil.Decode(tt.txHex)
+			require.NoError(t, err)
+
+			tx := new(types.Transaction)
+			err = tx.UnmarshalBinary(data)
+			require.NoError(t, err)
+
+			sender, err := ExtractSenderFromTx(context.Background(), tx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedSender, sender.Hex())
+		})
+	}
 }
 
+// TestParseRawTx verifies that raw transaction hex is correctly parsed.
 func TestParseRawTx(t *testing.T) {
 	t.Run("invalid params", func(t *testing.T) {
 		req := &RPCReq{
@@ -320,31 +397,27 @@ func TestParseRawTx(t *testing.T) {
 		_, err := parseRawTx(req)
 		require.Error(t, err)
 	})
+
+	t.Run("valid hex", func(t *testing.T) {
+		validTxHex := "0x02f8b28201a406849502f931849502f931830147f9948f3ddd0fbf3e78ca1d6c" +
+			"d17379ed88e261249b5280b84447e7ef2400000000000000000000000089c8b1" +
+			"b2774201bac50f627403eac1b732459cf7000000000000000000000000000000" +
+			"0000000000000000056bc75e2d63100000c080a0473c95566026c312c9664cd6" +
+			"1145d2f3e759d49209fe96011ac012884ec5b017a0763b58f6fa6096e6ba28ee" +
+			"08bfac58f58fb3b8bcef5af98578bdeaddf40bde42"
+		req := &RPCReq{
+			Method: "eth_sendRawTransaction",
+			Params: []byte(`["` + validTxHex + `"]`),
+		}
+
+		tx, err := parseRawTx(req)
+		require.NoError(t, err)
+		require.NotNil(t, tx)
+	})
 }
 
-func TestNewSenderHashRouter(t *testing.T) {
-	router := NewSenderHashRouter("my-secret-salt")
-	require.NotNil(t, router)
-	require.Equal(t, []byte("my-secret-salt"), router.salt)
-}
-
-func TestSenderHashRouter_EmptySalt(t *testing.T) {
-	router := NewSenderHashRouter("")
-
-	backends := []*Backend{
-		createMockBackend("backend-1", true),
-		createMockBackend("backend-2", true),
-	}
-
-	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-	selected := router.SelectBackend(sender, backends)
-
-	require.NotNil(t, selected)
-
-	selected2 := router.SelectBackend(sender, backends)
-	require.Equal(t, selected.Name, selected2.Name)
-}
-
+// TestSenderHashRouter_DifferentSendersDistribute verifies that different senders
+// are distributed across multiple backends (not all routed to the same one).
 func TestSenderHashRouter_DifferentSendersDistribute(t *testing.T) {
 	router := NewSenderHashRouter("distribution-salt")
 
@@ -365,47 +438,9 @@ func TestSenderHashRouter_DifferentSendersDistribute(t *testing.T) {
 
 	selections := make(map[string]bool)
 	for _, sender := range senders {
-		selected := router.SelectBackend(sender, backends)
-		selections[selected.Name] = true
+		ordered := router.OrderedBackendsForSender(sender, backends)
+		selections[ordered[0].Name] = true
 	}
 
 	require.GreaterOrEqual(t, len(selections), 2)
-}
-
-func BenchmarkSenderHashRouter_SelectBackend(b *testing.B) {
-	router := NewSenderHashRouter("benchmark-salt")
-
-	backends := []*Backend{
-		createMockBackend("backend-1", true),
-		createMockBackend("backend-2", true),
-		createMockBackend("backend-3", true),
-		createMockBackend("backend-4", true),
-		createMockBackend("backend-5", true),
-	}
-
-	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		router.SelectBackend(sender, backends)
-	}
-}
-
-func BenchmarkSenderHashRouter_OrderedBackendsForSender(b *testing.B) {
-	router := NewSenderHashRouter("benchmark-salt")
-
-	backends := []*Backend{
-		createMockBackend("backend-1", true),
-		createMockBackend("backend-2", true),
-		createMockBackend("backend-3", true),
-		createMockBackend("backend-4", true),
-		createMockBackend("backend-5", true),
-	}
-
-	sender := common.HexToAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f5e3E1")
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		router.OrderedBackendsForSender(sender, backends)
-	}
 }

--- a/proxyd/sender_hash_router_test.go
+++ b/proxyd/sender_hash_router_test.go
@@ -374,7 +374,7 @@ func TestParseRawTx(t *testing.T) {
 			Params: []byte(`"not an array"`),
 		}
 
-		_, err := parseRawTx(req)
+		_, err := ParseRawTx(req)
 		require.Error(t, err)
 	})
 
@@ -384,7 +384,7 @@ func TestParseRawTx(t *testing.T) {
 			Params: []byte(`[]`),
 		}
 
-		_, err := parseRawTx(req)
+		_, err := ParseRawTx(req)
 		require.Error(t, err)
 	})
 
@@ -394,7 +394,7 @@ func TestParseRawTx(t *testing.T) {
 			Params: []byte(`["not-valid-hex"]`),
 		}
 
-		_, err := parseRawTx(req)
+		_, err := ParseRawTx(req)
 		require.Error(t, err)
 	})
 
@@ -410,7 +410,7 @@ func TestParseRawTx(t *testing.T) {
 			Params: []byte(`["` + validTxHex + `"]`),
 		}
 
-		tx, err := parseRawTx(req)
+		tx, err := ParseRawTx(req)
 		require.NoError(t, err)
 		require.NotNil(t, tx)
 	})


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

## Architecture

### Highest Random Weighted Hashing

For each request, we compute a score for every backend: `score = SHA256(sender_address + salt + backend_name)`

Backends are sorted by:
1. Health status (healthy first)
2. Score (highest first)

The first backend in the sorted list handles the request. If it fails, the next one is tried.

### Salt Configuration

```
[backend_groups.mempool]
backends = ["node1", "node2", "node3"]
routing_strategy = "sender_hash"
sender_hash_salt = "$SENDER_HASH_SALT"
```

### Salt rotation

Salt rotation is manual and infrequent by design:
| Action | Command |
|--------|---------|
| Rotate salt | Update $SENDER_HASH_SALT env var, redeploy proxyd |

### Health-Aware Failover

The router integrates with backend_probe:
Backend.IsHealthy()
  → checks probe status (healthyProbe atomic bool)
  → checks error rate threshold
  → checks latency threshold

When primary backend is unhealthy:
1. Sorted list puts healthy backends first
2. Request goes to next-highest-scoring healthy backend
3. When primary recovers, traffic automatically returns (score unchanged)


### Other notes:

- Uses `release-rb` branch instead of `release` because it's synced with upstream which gives us `backend_probe` health checks

## Tests

Unit tests:
- Deterministic routing (same sender → same backend)
- Salt sensitivity (different salts → different routing)
- Health-aware sorting (healthy first, then by score)
- Failover behavior (primary down → secondary promoted)
- Concurrent access safety
- Sender extraction from signed transactions

Integration tests:
- Same sender → all requests to one backend, zero to others
- Different senders → distributed across backends
- Primary error → routes to different backend
- Non-sendRawTransaction → uses fallback routing

## TODO

- [x] Verify logic
- [ ] Manual QA