### PR TITLE
feat(proxyd): add Redis connection pool configuration options

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -59,36 +59,36 @@ type RedisConfig struct {
 	// Connection pool settings for performance tuning.
 	// PoolSize is the maximum number of socket connections.
 	// Default is 10 connections per every available CPU as reported by runtime.GOMAXPROCS.
-	PoolSize int `toml:"pool_size"`
+	PoolSize int `toml:"redis_pool_size"`
 	// MinIdleConns is the minimum number of idle connections to keep open.
 	// This helps reduce latency on sudden traffic spikes by having warm connections ready.
-	MinIdleConns int `toml:"min_idle_conns"`
+	MinIdleConns int `toml:"redis_min_idle_conns"`
 	// MaxIdleConns is the maximum number of idle connections to keep open.
 	// Setting this lower than PoolSize helps release unused connections.
 	// Default is 0 (no limit, same as PoolSize).
-	MaxIdleConns int `toml:"max_idle_conns"`
+	MaxIdleConns int `toml:"redis_max_idle_conns"`
 	// ReadTimeoutMS is the timeout in milliseconds for reading a single command reply.
 	// Default is 3000ms (3 seconds).
-	ReadTimeoutMS int `toml:"read_timeout_ms"`
+	ReadTimeoutMS int `toml:"redis_read_timeout_ms"`
 	// WriteTimeoutMS is the timeout in milliseconds for writing a single command.
 	// Default is 3000ms (3 seconds).
-	WriteTimeoutMS int `toml:"write_timeout_ms"`
+	WriteTimeoutMS int `toml:"redis_write_timeout_ms"`
 	// DialTimeoutMS is the timeout in milliseconds for establishing new connections.
 	// Default is 5000ms (5 seconds).
-	DialTimeoutMS int `toml:"dial_timeout_ms"`
+	DialTimeoutMS int `toml:"redis_dial_timeout_ms"`
 	// PoolTimeoutMS is the amount of time in milliseconds client waits for a connection
 	// if all connections are busy before returning an error.
 	// Default is ReadTimeout + 1 second.
-	PoolTimeoutMS int `toml:"pool_timeout_ms"`
+	PoolTimeoutMS int `toml:"redis_pool_timeout_ms"`
 	// MaxRetries is the maximum number of retries before giving up.
 	// Default is 3 retries; -1 disables retries.
-	MaxRetries int `toml:"max_retries"`
+	MaxRetries int `toml:"redis_max_retries"`
 	// MinRetryBackoffMS is the minimum backoff in milliseconds between each retry.
 	// Default is 8ms; -1 disables backoff.
-	MinRetryBackoffMS int `toml:"min_retry_backoff_ms"`
+	MinRetryBackoffMS int `toml:"redis_min_retry_backoff_ms"`
 	// MaxRetryBackoffMS is the maximum backoff in milliseconds between each retry.
 	// Default is 512ms; -1 disables backoff.
-	MaxRetryBackoffMS int `toml:"max_retry_backoff_ms"`
+	MaxRetryBackoffMS int `toml:"redis_max_retry_backoff_ms"`
 }
 
 type MetricsConfig struct {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -55,6 +55,40 @@ type RedisConfig struct {
 	ReadURL          string `toml:"read_url"`
 	FallbackToMemory bool   `toml:"fallback_to_memory"`
 	RedisCluster     bool   `toml:"redis_cluster"`
+
+	// Connection pool settings for performance tuning.
+	// PoolSize is the maximum number of socket connections.
+	// Default is 10 connections per every available CPU as reported by runtime.GOMAXPROCS.
+	PoolSize int `toml:"pool_size"`
+	// MinIdleConns is the minimum number of idle connections to keep open.
+	// This helps reduce latency on sudden traffic spikes by having warm connections ready.
+	MinIdleConns int `toml:"min_idle_conns"`
+	// MaxIdleConns is the maximum number of idle connections to keep open.
+	// Setting this lower than PoolSize helps release unused connections.
+	// Default is 0 (no limit, same as PoolSize).
+	MaxIdleConns int `toml:"max_idle_conns"`
+	// ReadTimeoutMS is the timeout in milliseconds for reading a single command reply.
+	// Default is 3000ms (3 seconds).
+	ReadTimeoutMS int `toml:"read_timeout_ms"`
+	// WriteTimeoutMS is the timeout in milliseconds for writing a single command.
+	// Default is 3000ms (3 seconds).
+	WriteTimeoutMS int `toml:"write_timeout_ms"`
+	// DialTimeoutMS is the timeout in milliseconds for establishing new connections.
+	// Default is 5000ms (5 seconds).
+	DialTimeoutMS int `toml:"dial_timeout_ms"`
+	// PoolTimeoutMS is the amount of time in milliseconds client waits for a connection
+	// if all connections are busy before returning an error.
+	// Default is ReadTimeout + 1 second.
+	PoolTimeoutMS int `toml:"pool_timeout_ms"`
+	// MaxRetries is the maximum number of retries before giving up.
+	// Default is 3 retries; -1 disables retries.
+	MaxRetries int `toml:"max_retries"`
+	// MinRetryBackoffMS is the minimum backoff in milliseconds between each retry.
+	// Default is 8ms; -1 disables backoff.
+	MinRetryBackoffMS int `toml:"min_retry_backoff_ms"`
+	// MaxRetryBackoffMS is the maximum backoff in milliseconds between each retry.
+	// Default is 512ms; -1 disables backoff.
+	MaxRetryBackoffMS int `toml:"max_retry_backoff_ms"`
 }
 
 type MetricsConfig struct {

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -39,25 +39,25 @@ url = "redis://localhost:6379"
 
 # Connection pool tuning (recommended for high-throughput deployments).
 # Maximum number of socket connections. Default: 100
-# pool_size = 100
+# redis_pool_size = 100
 # Minimum idle connections to keep warm. Default: 20
-# min_idle_conns = 20
+# redis_min_idle_conns = 20
 # Maximum idle connections. Default: 0 (no limit, same as pool_size)
-# max_idle_conns = 0
+# redis_max_idle_conns = 0
 # Read timeout in milliseconds. Default: 3000
-# read_timeout_ms = 3000
+# redis_read_timeout_ms = 3000
 # Write timeout in milliseconds. Default: 3000
-# write_timeout_ms = 3000
+# redis_write_timeout_ms = 3000
 # Dial timeout in milliseconds for new connections. Default: 5000
-# dial_timeout_ms = 5000
+# redis_dial_timeout_ms = 5000
 # Pool timeout in milliseconds (time to wait for available connection). Default: read_timeout + 1s
-# pool_timeout_ms = 4000
+# redis_pool_timeout_ms = 4000
 # Maximum retry attempts. Default: 3, set to -1 to disable retries.
-# max_retries = 3
+# redis_max_retries = 3
 # Minimum retry backoff in milliseconds. Default: 8, set to -1 to disable.
-# min_retry_backoff_ms = 8
+# redis_min_retry_backoff_ms = 8
 # Maximum retry backoff in milliseconds. Default: 512, set to -1 to disable.
-# max_retry_backoff_ms = 512
+# redis_max_retry_backoff_ms = 512
 
 [metrics]
 # Whether or not to enable Prometheus metrics.

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -28,6 +28,36 @@ log_level = "info"
 [redis]
 # URL to a Redis instance.
 url = "redis://localhost:6379"
+# Optional: URL to a Redis read replica for read operations.
+# read_url = "redis://localhost:6380"
+# Namespace prefix for all Redis keys.
+# namespace = "proxyd"
+# Fall back to in-memory cache if Redis connection fails.
+# fallback_to_memory = false
+# Enable Redis cluster mode for multi-node clusters.
+# redis_cluster = false
+
+# Connection pool tuning (recommended for high-throughput deployments).
+# Maximum number of socket connections. Default: 100
+# pool_size = 100
+# Minimum idle connections to keep warm. Default: 20
+# min_idle_conns = 20
+# Maximum idle connections. Default: 0 (no limit, same as pool_size)
+# max_idle_conns = 0
+# Read timeout in milliseconds. Default: 3000
+# read_timeout_ms = 3000
+# Write timeout in milliseconds. Default: 3000
+# write_timeout_ms = 3000
+# Dial timeout in milliseconds for new connections. Default: 5000
+# dial_timeout_ms = 5000
+# Pool timeout in milliseconds (time to wait for available connection). Default: read_timeout + 1s
+# pool_timeout_ms = 4000
+# Maximum retry attempts. Default: 3, set to -1 to disable retries.
+# max_retries = 3
+# Minimum retry backoff in milliseconds. Default: 8, set to -1 to disable.
+# min_retry_backoff_ms = 8
+# Maximum retry backoff in milliseconds. Default: 512, set to -1 to disable.
+# max_retry_backoff_ms = 512
 
 [metrics]
 # Whether or not to enable Prometheus metrics.

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -47,7 +47,7 @@ func Start(config *Config) (*Server, func(), error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		redisClient, err = NewRedisClient(rURL, config.Redis.RedisCluster)
+		redisClient, err = NewRedisClientWithConfig(rURL, config.Redis.RedisCluster, config.Redis)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -71,7 +71,7 @@ func Start(config *Config) (*Server, func(), error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		redisReadClient, err = NewRedisClient(rURL, config.Redis.RedisCluster)
+		redisReadClient, err = NewRedisClientWithConfig(rURL, config.Redis.RedisCluster, config.Redis)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -619,7 +619,7 @@ func Start(config *Config) (*Server, func(), error) {
 				if bgcfg.ConsensusHAHeartbeatInterval > 0 {
 					topts = append(topts, WithHeartbeatInterval(time.Duration(bgcfg.ConsensusHAHeartbeatInterval)))
 				}
-				consensusHARedisClient, err := NewRedisClient(bgcfg.ConsensusHARedis.URL, bgcfg.ConsensusHARedis.RedisCluster)
+				consensusHARedisClient, err := NewRedisClientWithConfig(bgcfg.ConsensusHARedis.URL, bgcfg.ConsensusHARedis.RedisCluster, bgcfg.ConsensusHARedis)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/proxyd/redis.go
+++ b/proxyd/redis.go
@@ -8,13 +8,30 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+const (
+	defaultPoolSize        = 100
+	defaultMinIdleConns    = 20
+	defaultReadTimeoutMS   = 3000
+	defaultWriteTimeoutMS  = 3000
+	defaultDialTimeoutMS   = 5000
+	defaultMaxRetries      = 3
+	defaultMinRetryBackoff = 8
+	defaultMaxRetryBackoff = 512
+)
+
 func NewRedisClient(url string, enable_cluster bool) (redis.UniversalClient, error) {
+	return NewRedisClientWithConfig(url, enable_cluster, RedisConfig{})
+}
+
+func NewRedisClientWithConfig(url string, enable_cluster bool, cfg RedisConfig) (redis.UniversalClient, error) {
 	if enable_cluster {
 		log.Info("Using cluster redis client.")
 		opts, err := redis.ParseClusterURL(url)
 		if err != nil {
 			return nil, err
 		}
+		applyClusterPoolConfig(opts, cfg)
+		logPoolConfig(cfg)
 		return redis.NewClusterClient(opts), nil
 	} else {
 		log.Info("Using default redis client.")
@@ -22,8 +39,162 @@ func NewRedisClient(url string, enable_cluster bool) (redis.UniversalClient, err
 		if err != nil {
 			return nil, err
 		}
+		applyPoolConfig(opts, cfg)
+		logPoolConfig(cfg)
 		return redis.NewClient(opts), nil
 	}
+}
+
+func applyPoolConfig(opts *redis.Options, cfg RedisConfig) {
+	if cfg.PoolSize > 0 {
+		opts.PoolSize = cfg.PoolSize
+	} else {
+		opts.PoolSize = defaultPoolSize
+	}
+
+	if cfg.MinIdleConns > 0 {
+		opts.MinIdleConns = cfg.MinIdleConns
+	} else {
+		opts.MinIdleConns = defaultMinIdleConns
+	}
+
+	if cfg.MaxIdleConns > 0 {
+		opts.MaxIdleConns = cfg.MaxIdleConns
+	}
+
+	if cfg.ReadTimeoutMS > 0 {
+		opts.ReadTimeout = time.Duration(cfg.ReadTimeoutMS) * time.Millisecond
+	} else {
+		opts.ReadTimeout = defaultReadTimeoutMS * time.Millisecond
+	}
+
+	if cfg.WriteTimeoutMS > 0 {
+		opts.WriteTimeout = time.Duration(cfg.WriteTimeoutMS) * time.Millisecond
+	} else {
+		opts.WriteTimeout = defaultWriteTimeoutMS * time.Millisecond
+	}
+
+	if cfg.DialTimeoutMS > 0 {
+		opts.DialTimeout = time.Duration(cfg.DialTimeoutMS) * time.Millisecond
+	} else {
+		opts.DialTimeout = defaultDialTimeoutMS * time.Millisecond
+	}
+
+	if cfg.PoolTimeoutMS > 0 {
+		opts.PoolTimeout = time.Duration(cfg.PoolTimeoutMS) * time.Millisecond
+	}
+
+	if cfg.MaxRetries != 0 {
+		opts.MaxRetries = cfg.MaxRetries
+	} else {
+		opts.MaxRetries = defaultMaxRetries
+	}
+
+	if cfg.MinRetryBackoffMS > 0 {
+		opts.MinRetryBackoff = time.Duration(cfg.MinRetryBackoffMS) * time.Millisecond
+	} else if cfg.MinRetryBackoffMS < 0 {
+		opts.MinRetryBackoff = -1
+	} else {
+		opts.MinRetryBackoff = defaultMinRetryBackoff * time.Millisecond
+	}
+
+	if cfg.MaxRetryBackoffMS > 0 {
+		opts.MaxRetryBackoff = time.Duration(cfg.MaxRetryBackoffMS) * time.Millisecond
+	} else if cfg.MaxRetryBackoffMS < 0 {
+		opts.MaxRetryBackoff = -1
+	} else {
+		opts.MaxRetryBackoff = defaultMaxRetryBackoff * time.Millisecond
+	}
+}
+
+func applyClusterPoolConfig(opts *redis.ClusterOptions, cfg RedisConfig) {
+	if cfg.PoolSize > 0 {
+		opts.PoolSize = cfg.PoolSize
+	} else {
+		opts.PoolSize = defaultPoolSize
+	}
+
+	if cfg.MinIdleConns > 0 {
+		opts.MinIdleConns = cfg.MinIdleConns
+	} else {
+		opts.MinIdleConns = defaultMinIdleConns
+	}
+
+	if cfg.MaxIdleConns > 0 {
+		opts.MaxIdleConns = cfg.MaxIdleConns
+	}
+
+	if cfg.ReadTimeoutMS > 0 {
+		opts.ReadTimeout = time.Duration(cfg.ReadTimeoutMS) * time.Millisecond
+	} else {
+		opts.ReadTimeout = defaultReadTimeoutMS * time.Millisecond
+	}
+
+	if cfg.WriteTimeoutMS > 0 {
+		opts.WriteTimeout = time.Duration(cfg.WriteTimeoutMS) * time.Millisecond
+	} else {
+		opts.WriteTimeout = defaultWriteTimeoutMS * time.Millisecond
+	}
+
+	if cfg.DialTimeoutMS > 0 {
+		opts.DialTimeout = time.Duration(cfg.DialTimeoutMS) * time.Millisecond
+	} else {
+		opts.DialTimeout = defaultDialTimeoutMS * time.Millisecond
+	}
+
+	if cfg.PoolTimeoutMS > 0 {
+		opts.PoolTimeout = time.Duration(cfg.PoolTimeoutMS) * time.Millisecond
+	}
+
+	if cfg.MaxRetries != 0 {
+		opts.MaxRetries = cfg.MaxRetries
+	} else {
+		opts.MaxRetries = defaultMaxRetries
+	}
+
+	if cfg.MinRetryBackoffMS > 0 {
+		opts.MinRetryBackoff = time.Duration(cfg.MinRetryBackoffMS) * time.Millisecond
+	} else if cfg.MinRetryBackoffMS < 0 {
+		opts.MinRetryBackoff = -1
+	} else {
+		opts.MinRetryBackoff = defaultMinRetryBackoff * time.Millisecond
+	}
+
+	if cfg.MaxRetryBackoffMS > 0 {
+		opts.MaxRetryBackoff = time.Duration(cfg.MaxRetryBackoffMS) * time.Millisecond
+	} else if cfg.MaxRetryBackoffMS < 0 {
+		opts.MaxRetryBackoff = -1
+	} else {
+		opts.MaxRetryBackoff = defaultMaxRetryBackoff * time.Millisecond
+	}
+}
+
+func logPoolConfig(cfg RedisConfig) {
+	poolSize := cfg.PoolSize
+	if poolSize == 0 {
+		poolSize = defaultPoolSize
+	}
+	minIdleConns := cfg.MinIdleConns
+	if minIdleConns == 0 {
+		minIdleConns = defaultMinIdleConns
+	}
+	readTimeout := cfg.ReadTimeoutMS
+	if readTimeout == 0 {
+		readTimeout = defaultReadTimeoutMS
+	}
+	writeTimeout := cfg.WriteTimeoutMS
+	if writeTimeout == 0 {
+		writeTimeout = defaultWriteTimeoutMS
+	}
+
+	log.Info("Redis connection pool configured",
+		"pool_size", poolSize,
+		"min_idle_conns", minIdleConns,
+		"max_idle_conns", cfg.MaxIdleConns,
+		"read_timeout_ms", readTimeout,
+		"write_timeout_ms", writeTimeout,
+		"max_retries", cfg.MaxRetries,
+	)
 }
 
 func CheckRedisConnection(client redis.UniversalClient) error {

--- a/proxyd/redis_test.go
+++ b/proxyd/redis_test.go
@@ -1,0 +1,116 @@
+package proxyd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyPoolConfig_CustomValues(t *testing.T) {
+	cfg := RedisConfig{
+		PoolSize:          50,
+		MinIdleConns:      10,
+		MaxIdleConns:      30,
+		ReadTimeoutMS:     2000,
+		WriteTimeoutMS:    1500,
+		DialTimeoutMS:     3000,
+		PoolTimeoutMS:     4000,
+		MaxRetries:        5,
+		MinRetryBackoffMS: 16,
+		MaxRetryBackoffMS: 1024,
+	}
+
+	opts := &redis.Options{}
+	applyPoolConfig(opts, cfg)
+
+	require.Equal(t, 50, opts.PoolSize)
+	require.Equal(t, 10, opts.MinIdleConns)
+	require.Equal(t, 30, opts.MaxIdleConns)
+	require.Equal(t, 2000*time.Millisecond, opts.ReadTimeout)
+	require.Equal(t, 1500*time.Millisecond, opts.WriteTimeout)
+	require.Equal(t, 3000*time.Millisecond, opts.DialTimeout)
+	require.Equal(t, 4000*time.Millisecond, opts.PoolTimeout)
+	require.Equal(t, 5, opts.MaxRetries)
+	require.Equal(t, 16*time.Millisecond, opts.MinRetryBackoff)
+	require.Equal(t, 1024*time.Millisecond, opts.MaxRetryBackoff)
+}
+
+func TestApplyPoolConfig_Defaults(t *testing.T) {
+	cfg := RedisConfig{}
+
+	opts := &redis.Options{}
+	applyPoolConfig(opts, cfg)
+
+	require.Equal(t, defaultPoolSize, opts.PoolSize)
+	require.Equal(t, defaultMinIdleConns, opts.MinIdleConns)
+	require.Equal(t, 0, opts.MaxIdleConns)
+	require.Equal(t, defaultReadTimeoutMS*time.Millisecond, opts.ReadTimeout)
+	require.Equal(t, defaultWriteTimeoutMS*time.Millisecond, opts.WriteTimeout)
+	require.Equal(t, defaultDialTimeoutMS*time.Millisecond, opts.DialTimeout)
+	require.Equal(t, time.Duration(0), opts.PoolTimeout)
+	require.Equal(t, defaultMaxRetries, opts.MaxRetries)
+	require.Equal(t, defaultMinRetryBackoff*time.Millisecond, opts.MinRetryBackoff)
+	require.Equal(t, defaultMaxRetryBackoff*time.Millisecond, opts.MaxRetryBackoff)
+}
+
+func TestApplyPoolConfig_DisableRetryBackoff(t *testing.T) {
+	cfg := RedisConfig{
+		MinRetryBackoffMS: -1,
+		MaxRetryBackoffMS: -1,
+	}
+
+	opts := &redis.Options{}
+	applyPoolConfig(opts, cfg)
+
+	require.Equal(t, time.Duration(-1), opts.MinRetryBackoff)
+	require.Equal(t, time.Duration(-1), opts.MaxRetryBackoff)
+}
+
+func TestApplyClusterPoolConfig_CustomValues(t *testing.T) {
+	cfg := RedisConfig{
+		PoolSize:          50,
+		MinIdleConns:      10,
+		MaxIdleConns:      30,
+		ReadTimeoutMS:     2000,
+		WriteTimeoutMS:    1500,
+		DialTimeoutMS:     3000,
+		PoolTimeoutMS:     4000,
+		MaxRetries:        5,
+		MinRetryBackoffMS: 16,
+		MaxRetryBackoffMS: 1024,
+	}
+
+	opts := &redis.ClusterOptions{}
+	applyClusterPoolConfig(opts, cfg)
+
+	require.Equal(t, 50, opts.PoolSize)
+	require.Equal(t, 10, opts.MinIdleConns)
+	require.Equal(t, 30, opts.MaxIdleConns)
+	require.Equal(t, 2000*time.Millisecond, opts.ReadTimeout)
+	require.Equal(t, 1500*time.Millisecond, opts.WriteTimeout)
+	require.Equal(t, 3000*time.Millisecond, opts.DialTimeout)
+	require.Equal(t, 4000*time.Millisecond, opts.PoolTimeout)
+	require.Equal(t, 5, opts.MaxRetries)
+	require.Equal(t, 16*time.Millisecond, opts.MinRetryBackoff)
+	require.Equal(t, 1024*time.Millisecond, opts.MaxRetryBackoff)
+}
+
+func TestApplyClusterPoolConfig_Defaults(t *testing.T) {
+	cfg := RedisConfig{}
+
+	opts := &redis.ClusterOptions{}
+	applyClusterPoolConfig(opts, cfg)
+
+	require.Equal(t, defaultPoolSize, opts.PoolSize)
+	require.Equal(t, defaultMinIdleConns, opts.MinIdleConns)
+	require.Equal(t, 0, opts.MaxIdleConns)
+	require.Equal(t, defaultReadTimeoutMS*time.Millisecond, opts.ReadTimeout)
+	require.Equal(t, defaultWriteTimeoutMS*time.Millisecond, opts.WriteTimeout)
+	require.Equal(t, defaultDialTimeoutMS*time.Millisecond, opts.DialTimeout)
+	require.Equal(t, time.Duration(0), opts.PoolTimeout)
+	require.Equal(t, defaultMaxRetries, opts.MaxRetries)
+	require.Equal(t, defaultMinRetryBackoff*time.Millisecond, opts.MinRetryBackoff)
+	require.Equal(t, defaultMaxRetryBackoff*time.Millisecond, opts.MaxRetryBackoff)
+}


### PR DESCRIPTION
## Summary
- Adds configurable Redis connection pool settings (pool size, idle connections, timeouts, retries) to `RedisConfig`
- Applies sensible defaults for high-throughput deployments (100 pool size, 20 min idle connections)
- Documents all new options in `example.config.toml` with explanations

## Changes
- `proxyd/config.go`: Added 11 new pool configuration fields with documentation
- `proxyd/redis.go`: New `NewRedisClientWithConfig()` function that applies pool settings to both standard and cluster Redis clients
- `proxyd/proxyd.go`: Updated all Redis client instantiations to use the new config-aware constructor
- `proxyd/example.config.toml`: Added commented examples for all new configuration options