### PR TITLE
Fix: Prevent accidental exposure of local signer overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ coverage.out
 bin/
 
 # Local AWS config
-.aws 
+.aws
+
+# Local signer overrides
+.envrc.local


### PR DESCRIPTION
### Description
This PR addresses future secret-file exposure risks within the `infra-routing` repository.

**Vulnerabilities & Security Defects Remediated:**
* **Future Secret-File Exposure (`.gitignore`):** Local signer overrides were previously at risk of being committed to the repository. The `.gitignore` policy has been updated to explicitly ignore `.envrc.local`. This prevents local credential files and signer configurations from accidentally leaking into the Git history.